### PR TITLE
build: use ubuntu-lts-latest in readthedocs build

### DIFF
--- a/backend/.readthedocs.yaml
+++ b/backend/.readthedocs.yaml
@@ -12,7 +12,7 @@ sphinx:
 
 # Set the version of python needed to build these docs.
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-lts-latest"
   tools:
     python: "3.12"
 


### PR DESCRIPTION
- PR created under the [issue](https://github.com/openedx/public-engineering/issues/418) to update the os version in the `readthedocs` build workflow.