### PR TITLE
chore: update litellm dependencies for stream

### DIFF
--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -165,6 +165,8 @@ frozenlist==1.8.0
     #   aiosignal
 fsspec==2025.9.0
     # via huggingface-hub
+grpcio==1.76.0
+    # via litellm
 h11==0.16.0
     # via httpcore
 hf-xet==1.1.10
@@ -211,15 +213,16 @@ jsonschema-specifications==2025.9.1
     # via jsonschema
 kombu==5.6.1
     # via celery
-litellm==1.78.2
-    # via -r requirements/base.in
+litellm==1.80.16
+    # via
+    #   -r requirements/base.in
 markupsafe==3.0.3
     # via jinja2
 multidict==6.7.0
     # via
     #   aiohttp
     #   yarl
-openai==2.4.0
+openai==2.15.0
     # via litellm
 openedx-atlas==0.7.0
     # via -r requirements/base.in
@@ -330,6 +333,7 @@ typing-extensions==4.13.2
     #   beautifulsoup4
     #   edx-opaque-keys
     #   exceptiongroup
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   pydantic

--- a/backend/requirements/constraints.txt
+++ b/backend/requirements/constraints.txt
@@ -10,3 +10,5 @@
 
 # Common constraints for edx repos
 -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+
+litellm==1.80.16

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -299,6 +299,10 @@ fsspec==2025.9.0
     # via
     #   -r requirements/quality.txt
     #   huggingface-hub
+grpcio==1.76.0
+    # via
+    #   -r requirements/quality.txt
+    #   litellm
 h11==0.16.0
     # via
     #   -r requirements/quality.txt
@@ -376,8 +380,9 @@ kombu==5.6.1
     # via
     #   -r requirements/quality.txt
     #   celery
-litellm==1.78.2
-    # via -r requirements/quality.txt
+litellm==1.80.16
+    # via
+    #   -r requirements/quality.txt
 lxml[html-clean]==5.3.2
     # via
     #   edx-i18n-tools
@@ -397,7 +402,7 @@ multidict==6.7.0
     #   -r requirements/quality.txt
     #   aiohttp
     #   yarl
-openai==2.4.0
+openai==2.15.0
     # via
     #   -r requirements/quality.txt
     #   litellm
@@ -644,6 +649,7 @@ typing-extensions==4.13.2
     #   beautifulsoup4
     #   edx-opaque-keys
     #   exceptiongroup
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   pydantic

--- a/backend/requirements/doc.txt
+++ b/backend/requirements/doc.txt
@@ -272,6 +272,10 @@ fsspec==2025.9.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
+grpcio==1.76.0
+    # via
+    #   -r requirements/test.txt
+    #   litellm
 h11==0.16.0
     # via
     #   -r requirements/test.txt
@@ -361,8 +365,9 @@ kombu==5.6.1
     # via
     #   -r requirements/test.txt
     #   celery
-litellm==1.78.2
-    # via -r requirements/test.txt
+litellm==1.80.16
+    # via
+    #   -r requirements/test.txt
 markdown-it-py==3.0.0
     # via rich
 markupsafe==3.0.3
@@ -382,7 +387,7 @@ multidict==6.7.0
     #   yarl
 nh3==0.2.21
     # via readme-renderer
-openai==2.4.0
+openai==2.15.0
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -617,6 +622,7 @@ typing-extensions==4.13.2
     #   beautifulsoup4
     #   edx-opaque-keys
     #   exceptiongroup
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   pydantic

--- a/backend/requirements/quality.txt
+++ b/backend/requirements/quality.txt
@@ -263,6 +263,10 @@ fsspec==2025.9.0
     # via
     #   -r requirements/test.txt
     #   huggingface-hub
+grpcio==1.76.0
+    # via
+    #   -r requirements/test.txt
+    #   litellm
 h11==0.16.0
     # via
     #   -r requirements/test.txt
@@ -339,8 +343,9 @@ kombu==5.6.1
     # via
     #   -r requirements/test.txt
     #   celery
-litellm==1.78.2
-    # via -r requirements/test.txt
+litellm==1.80.16
+    # via
+    #   -r requirements/test.txt
 markupsafe==3.0.3
     # via
     #   -r requirements/test.txt
@@ -352,7 +357,7 @@ multidict==6.7.0
     #   -r requirements/test.txt
     #   aiohttp
     #   yarl
-openai==2.4.0
+openai==2.15.0
     # via
     #   -r requirements/test.txt
     #   litellm
@@ -556,6 +561,7 @@ typing-extensions==4.13.2
     #   beautifulsoup4
     #   edx-opaque-keys
     #   exceptiongroup
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   pydantic

--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -247,6 +247,10 @@ fsspec==2025.9.0
     # via
     #   -r requirements/base.txt
     #   huggingface-hub
+grpcio==1.76.0
+    # via
+    #   -r requirements/base.txt
+    #   litellm
 h11==0.16.0
     # via
     #   -r requirements/base.txt
@@ -317,8 +321,9 @@ kombu==5.6.1
     # via
     #   -r requirements/base.txt
     #   celery
-litellm==1.78.2
-    # via -r requirements/base.txt
+litellm==1.80.16
+    # via
+    #   -r requirements/base.txt
 markupsafe==3.0.3
     # via
     #   -r requirements/base.txt
@@ -328,7 +333,7 @@ multidict==6.7.0
     #   -r requirements/base.txt
     #   aiohttp
     #   yarl
-openai==2.4.0
+openai==2.15.0
     # via
     #   -r requirements/base.txt
     #   litellm
@@ -504,6 +509,7 @@ typing-extensions==4.13.2
     #   beautifulsoup4
     #   edx-opaque-keys
     #   exceptiongroup
+    #   grpcio
     #   huggingface-hub
     #   openai
     #   pydantic


### PR DESCRIPTION
This pull request updates the backend Python dependencies, primarily to upgrade `litellm` to avoid import proxy dependencies for streaming responses.

The issue about this change is: https://github.com/BerriAI/litellm/issues/18193 - Merged at 1.80.11
