### PR TITLE
chore: log complete exception in early return error responses

### DIFF
--- a/backend/openedx_ai_extensions/processors/educator_assistant_processor.py
+++ b/backend/openedx_ai_extensions/processors/educator_assistant_processor.py
@@ -64,7 +64,7 @@ class EducatorAssistantProcessor(LitellmProcessor):
             }
 
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error calling LiteLLM: {e}")
+            logger.exception(f"Error calling LiteLLM: {e}")
             return {"error": f"AI processing failed: {str(e)}"}
 
     def generate_quiz_questions(self, input_data):
@@ -81,7 +81,7 @@ class EducatorAssistantProcessor(LitellmProcessor):
             with open(prompt_file_path, "r") as f:
                 prompt = f.read()
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error loading prompt template: {e}")
+            logger.exception(f"Error loading prompt template: {e}")
             return {"error": "Failed to load prompt template."}
 
         if '{{NUM_QUESTIONS}}' in prompt:

--- a/backend/openedx_ai_extensions/processors/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm_processor.py
@@ -172,7 +172,7 @@ class LLMProcessor(LitellmProcessor):
             return result
 
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error calling LiteLLM: {e}")
+            logger.exception(f"Error calling LiteLLM: {e}")
             return {"error": f"AI processing failed: {str(e)}"}
 
     def _call_completion_wrapper(self, system_role):
@@ -223,7 +223,7 @@ class LLMProcessor(LitellmProcessor):
         except Exception as e:  # pylint: disable=broad-exception-caught
             # Catch errors that occur during the INITIAL API call (before streaming starts)
             error_message = f"Error during initial AI completion call: {e}"
-            logger.error(error_message, exc_info=True)
+            logger.exception(error_message, exc_info=True)
             # Always return a dictionary error in this outer block
             return {"error": f"AI processing failed: {str(e)}"}
 

--- a/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
@@ -183,7 +183,7 @@ class SubmissionProcessor:
                 ),
             }
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error retrieving previous messages: {e}")
+            logger.exception(f"Error retrieving previous messages: {e}")
             return {"error": f"Failed to load previous messages: {str(e)}"}
 
     def update_chat_submission(self, messages):


### PR DESCRIPTION
This pull request improves error logging across several processor classes by switching from `logger.error` to `logger.exception` when handling exceptions. This change ensures that stack traces are included in the logs, making it easier to debug issues related to AI processing, prompt loading, and message retrieval.

**Error logging improvements:**

* Changed exception handling in `educator_assistant_processor.py` to use `logger.exception` for errors during LiteLLM calls and prompt template loading, providing more detailed logs. [[1]](diffhunk://#diff-d1e957c5e259abf1761a12d972f48ba5da0ee5125cd860ca4101615fb3ec3650L67-R67) [[2]](diffhunk://#diff-d1e957c5e259abf1761a12d972f48ba5da0ee5125cd860ca4101615fb3ec3650L84-R84)
* Updated `llm_processor.py` to use `logger.exception` for errors in both LiteLLM calls and initial AI completion calls, ensuring stack traces are logged. [[1]](diffhunk://#diff-375cfaa4589fe4f16f2d11c602469821024406ba835290f6d60d7be35c3ac9d5L175-R175) [[2]](diffhunk://#diff-375cfaa4589fe4f16f2d11c602469821024406ba835290f6d60d7be35c3ac9d5L226-R226)
* Modified `submission_processor.py` to use `logger.exception` when failing to retrieve previous messages, improving error traceability.