### PR TITLE
fix: add validation to the profile if the prompt_template does not exist

### DIFF
--- a/backend/tests/test_template_utils.py
+++ b/backend/tests/test_template_utils.py
@@ -7,8 +7,10 @@ from pathlib import Path
 
 from django.test import TestCase, override_settings
 
+from openedx_ai_extensions.models import PromptTemplate
 from openedx_ai_extensions.workflows.template_utils import (
     WORKFLOW_SCHEMA,
+    _validate_prompt_templates,
     _validate_semantics,
     discover_templates,
     get_effective_config,
@@ -638,6 +640,139 @@ class TestValidateSemantics(TestCase):
         errors = _validate_semantics(config)
 
         self.assertGreater(len(errors), 0)
+
+
+class TestValidatePromptTemplates(TestCase):
+    """Tests for _validate_prompt_templates function."""
+
+    def test_no_prompt_template_no_errors(self):
+        """Test that configs without prompt_template produce no errors."""
+        processor_config = {
+            "LLMProcessor": {"function": "summarize_content", "provider": "default"},
+            "OpenEdXProcessor": {"function": "get_location_content"},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(errors, [])
+
+    def test_existing_slug_no_errors(self):
+        """Test that referencing an existing prompt template by slug produces no errors."""
+        template = PromptTemplate.objects.create(
+            slug="test-existing-slug",
+            body="You are a helpful AI assistant."
+        )
+        processor_config = {
+            "LLMProcessor": {"prompt_template": template.slug},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(errors, [])
+
+    def test_existing_uuid_no_errors(self):
+        """Test that referencing an existing prompt template by UUID produces no errors."""
+        template = PromptTemplate.objects.create(
+            slug="test-existing-uuid",
+            body="You are a helpful AI assistant."
+        )
+        processor_config = {
+            "LLMProcessor": {"prompt_template": str(template.id)},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(errors, [])
+
+    def test_nonexistent_slug_produces_error(self):
+        """Test that referencing a nonexistent slug produces a validation error."""
+        processor_config = {
+            "LLMProcessor": {"prompt_template": "slug-que-no-existe"},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("slug-que-no-existe", errors[0])
+        self.assertIn("does not exist", errors[0])
+        self.assertIn("LLMProcessor", errors[0])
+
+    def test_nonexistent_uuid_produces_error(self):
+        """Test that referencing a nonexistent UUID produces a validation error."""
+        processor_config = {
+            "LLMProcessor": {"prompt_template": "12345678-1234-1234-1234-123456789abc"},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("12345678-1234-1234-1234-123456789abc", errors[0])
+        self.assertIn("does not exist", errors[0])
+
+    def test_multiple_processors_with_invalid_templates(self):
+        """Test that errors are reported for each processor with an invalid prompt_template."""
+        processor_config = {
+            "LLMProcessor": {"prompt_template": "nonexistent-1"},
+            "EducatorAssistantProcessor": {"prompt_template": "nonexistent-2"},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(len(errors), 2)
+        self.assertTrue(any("nonexistent-1" in e for e in errors))
+        self.assertTrue(any("nonexistent-2" in e for e in errors))
+
+    def test_mixed_valid_and_invalid_templates(self):
+        """Test mix of valid and invalid prompt_template references."""
+        template = PromptTemplate.objects.create(
+            slug="valid-template",
+            body="A valid prompt."
+        )
+        processor_config = {
+            "LLMProcessor": {"prompt_template": template.slug},
+            "EducatorAssistantProcessor": {"prompt_template": "invalid-template"},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(len(errors), 1)
+        self.assertIn("invalid-template", errors[0])
+        self.assertIn("EducatorAssistantProcessor", errors[0])
+
+    def test_empty_prompt_template_no_errors(self):
+        """Test that empty string or null prompt_template is skipped (no error)."""
+        processor_config = {
+            "LLMProcessor": {"prompt_template": ""},
+            "OpenEdXProcessor": {"prompt_template": None},
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(errors, [])
+
+    def test_non_dict_processor_value_skipped(self):
+        """Test that non-dict processor values are skipped without error."""
+        processor_config = {
+            "LLMProcessor": "not a dict",
+        }
+        errors = _validate_prompt_templates(processor_config)
+        self.assertEqual(errors, [])
+
+    def test_full_validation_catches_nonexistent_prompt_template(self):
+        """Test that validate_workflow_config catches nonexistent prompt_template (integration)."""
+        config = {
+            "schema_version": "1.0",
+            "orchestrator_class": "DirectLLMResponse",
+            "processor_config": {
+                "LLMProcessor": {"prompt_template": "does-not-exist"},
+            },
+            "actuator_config": {"UIComponents": {"request": {}, "response": {}}},
+        }
+        is_valid, errors = validate_workflow_config(config)
+        self.assertFalse(is_valid)
+        self.assertTrue(any("does-not-exist" in e for e in errors))
+
+    def test_full_validation_passes_with_existing_prompt_template(self):
+        """Test that validate_workflow_config passes with an existing prompt_template."""
+        PromptTemplate.objects.create(
+            slug="real-template",
+            body="This prompt exists."
+        )
+        config = {
+            "schema_version": "1.0",
+            "orchestrator_class": "DirectLLMResponse",
+            "processor_config": {
+                "LLMProcessor": {"prompt_template": "real-template"},
+            },
+            "actuator_config": {"UIComponents": {"request": {}, "response": {}}},
+        }
+        is_valid, errors = validate_workflow_config(config)
+        self.assertTrue(is_valid)
+        self.assertEqual(errors, [])
 
 
 class TestGetEffectiveConfig(TestCase):

--- a/backend/tests/test_template_utils.py
+++ b/backend/tests/test_template_utils.py
@@ -962,3 +962,78 @@ class TestWorkflowSchema(TestCase):
         # Both must be objects
         self.assertEqual(ui_components_props["properties"]["request"]["type"], "object")
         self.assertEqual(ui_components_props["properties"]["response"]["type"], "object")
+
+
+class TestAdminFormPromptTemplateValidation(TestCase):
+    """Tests that the Admin form blocks saving when prompt_template references are invalid."""
+
+    def setUp(self):
+        """Set up a temp directory with a valid base template."""
+        self.tmpdir = tempfile.mkdtemp()
+        self.temp_path = Path(self.tmpdir)
+
+        base_template = self.temp_path / "base_valid.json"
+        base_template.write_text('''{
+            "schema_version": "1.0",
+            "orchestrator_class": "DirectLLMResponse",
+            "processor_config": {
+                "LLMProcessor": {"provider": "default"}
+            },
+            "actuator_config": {
+                "UIComponents": {
+                    "request": {"component": "AIRequestComponent"},
+                    "response": {"component": "AIResponseComponent"}
+                }
+            }
+        }''')
+
+    def tearDown(self):
+        """Clean up temporary directory."""
+        shutil.rmtree(self.tmpdir)
+
+    def test_admin_form_rejects_nonexistent_prompt_template(self):
+        """Test that the admin form raises ValidationError for nonexistent prompt_template."""
+        from openedx_ai_extensions.admin import AIWorkflowProfileAdminForm  # pylint: disable=import-outside-toplevel
+
+        form_data = {
+            'slug': 'test-profile',
+            'base_filepath': 'base_valid.json',
+            'content_patch': '{"processor_config": {"LLMProcessor": {"prompt_template": "no-existe"}}}',
+        }
+
+        with override_settings(WORKFLOW_TEMPLATE_DIRS=[self.tmpdir]):
+            form = AIWorkflowProfileAdminForm(data=form_data)
+            self.assertFalse(form.is_valid())
+            # The error should mention the nonexistent prompt template
+            all_errors = str(form.errors)
+            self.assertIn("no-existe", all_errors)
+
+    def test_admin_form_accepts_existing_prompt_template(self):
+        """Test that the admin form accepts a valid prompt_template reference."""
+        from openedx_ai_extensions.admin import AIWorkflowProfileAdminForm  # pylint: disable=import-outside-toplevel
+
+        PromptTemplate.objects.create(slug="valid-admin-template", body="A real prompt.")
+
+        form_data = {
+            'slug': 'test-profile-valid',
+            'base_filepath': 'base_valid.json',
+            'content_patch': '{"processor_config": {"LLMProcessor": {"prompt_template": "valid-admin-template"}}}',
+        }
+
+        with override_settings(WORKFLOW_TEMPLATE_DIRS=[self.tmpdir]):
+            form = AIWorkflowProfileAdminForm(data=form_data)
+            self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")
+
+    def test_admin_form_accepts_no_prompt_template(self):
+        """Test that the admin form accepts config without prompt_template."""
+        from openedx_ai_extensions.admin import AIWorkflowProfileAdminForm  # pylint: disable=import-outside-toplevel
+
+        form_data = {
+            'slug': 'test-profile-no-pt',
+            'base_filepath': 'base_valid.json',
+            'content_patch': '',
+        }
+
+        with override_settings(WORKFLOW_TEMPLATE_DIRS=[self.tmpdir]):
+            form = AIWorkflowProfileAdminForm(data=form_data)
+            self.assertTrue(form.is_valid(), f"Form errors: {form.errors}")


### PR DESCRIPTION
related issue: https://github.com/openedx/openedx-ai-extensions/issues/89#event-22593975320

<div class="value" style="width: 292.003px; white-space: normal; overflow-wrap: anywhere;"><div class="chat-markdown-part rendered-markdown" style="margin-bottom: 0px; line-height: 1.5em; font-size: 13px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif;"><h2 style="line-height: normal; font-size: 16.003px; font-weight: 600; margin: 16px 0px 8px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif;">Validate<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 14.7708px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">prompt_template</code><span> </span>existence in<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 14.7708px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">AIWorkflowProfile</code></h2><h3 style="line-height: normal; font-size: 13px; font-weight: unset; margin: 0px 0px 8px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif;">Description</h3><p style="margin: 0px 0px 16px;">Prompt templates can be referenced by slug or UUID in workflow profiles, but there was no validation checking if the referenced template actually exists in the database. This caused silent failures at runtime — the system would fall back to inline prompts or send no custom prompt to the LLM without any warning.</p><h3 style="line-height: normal; font-size: 13px; font-weight: unset; margin: 0px 0px 8px; font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif;">Changes</h3><ul style="padding-inline-start: 24px;"><li><strong><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">template_utils.py</code></strong>: Added<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">_validate_prompt_templates()</code><span> </span>function that iterates over all processors in<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">processor_config</code>, checks for<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">prompt_template</code><span> </span>fields, and verifies they exist in the DB via<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">PromptTemplate.load_prompt()</code>. Integrated into the existing<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">_validate_semantics()</code><span> </span>pipeline.</li><li><strong><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">admin.py</code></strong>: Added<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">clean()</code><span> </span>method to<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">AIWorkflowProfileAdminForm</code><span> </span>that builds the effective config (base template + patch) and runs<span> </span><code style="font-family: &quot;Ubuntu Mono&quot;, &quot;Liberation Mono&quot;, &quot;DejaVu Sans Mono&quot;, &quot;Courier New&quot;, monospace; font-size: 11.999px; color: rgb(208, 208, 208); background-color: rgb(60, 60, 60); padding: 1px 3px; border-radius: 4px; white-space: pre-wrap;">validate_workflow_config()</code>. Invalid prompt templates now<span> </span><strong>block saving</strong><span> </span>in Django Admin with a descriptive error message.</li></ul>

## Tests
Added TestValidatePromptTemplates covering: existing slug/UUID, nonexistent slug/UUID, multiple processors, mixed valid/invalid, empty/null values, and Admin form integration

<img width="1510" height="121" alt="image" src="https://github.com/user-attachments/assets/23ef6003-3ce5-4375-a852-1b8502cead95" />