### PR TITLE
refactor: move orchestrators to it's own folder and move run_async to SessionOrchestrator

### DIFF
--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -7,6 +7,7 @@ import logging
 from django.conf import settings
 
 from openedx_ai_extensions.functions.decorators import TOOLS_SCHEMA
+from openedx_ai_extensions.models import PromptTemplate
 
 logger = logging.getLogger(__name__)
 
@@ -92,7 +93,6 @@ class LitellmProcessor:
         Returns:
             str or None: The prompt text
         """
-        from openedx_ai_extensions.models import PromptTemplate  # pylint: disable=import-outside-toplevel
 
         # Try loading from PromptTemplate (handles both slug and UUID)
         template_id = self.config.get("prompt_template")

--- a/backend/openedx_ai_extensions/tasks.py
+++ b/backend/openedx_ai_extensions/tasks.py
@@ -1,6 +1,8 @@
 """
 Celery tasks that will be registered.
 """
+
 # pylint: disable=unused-import
-from openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator import \
-    _execute_orchestrator_async  # noqa: F401
+from openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator import (
+    _execute_orchestrator_async,
+)  # noqa: F401

--- a/backend/openedx_ai_extensions/tasks.py
+++ b/backend/openedx_ai_extensions/tasks.py
@@ -2,4 +2,5 @@
 Celery tasks that will be registered.
 """
 # pylint: disable=unused-import
-from openedx_ai_extensions.workflows.orchestrators import _execute_orchestrator_async  # noqa: F401
+from openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator import \
+    _execute_orchestrator_async  # noqa: F401

--- a/backend/openedx_ai_extensions/tasks.py
+++ b/backend/openedx_ai_extensions/tasks.py
@@ -3,6 +3,6 @@ Celery tasks that will be registered.
 """
 
 # pylint: disable=unused-import
-from openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator import (
+from openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator import (  # noqa: F401
     _execute_orchestrator_async,
-)  # noqa: F401
+)

--- a/backend/openedx_ai_extensions/workflows/orchestrators/__init__.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/__init__.py
@@ -1,0 +1,10 @@
+"""
+Orchestrators package for AI workflow execution.
+
+This package provides the base orchestrator and concrete implementations.
+"""
+from .base_orchestrator import BaseOrchestrator
+
+__all__ = [
+    "BaseOrchestrator",
+]

--- a/backend/openedx_ai_extensions/workflows/orchestrators/base_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/base_orchestrator.py
@@ -1,0 +1,86 @@
+"""
+Base orchestrator class for AI workflow execution.
+"""
+import importlib
+import logging
+
+from eventtracking import tracker
+
+logger = logging.getLogger(__name__)
+
+
+class BaseOrchestrator:
+    """Base class for workflow orchestrators."""
+
+    def __init__(self, workflow, user, context):
+        self.workflow = workflow
+        self.user = user
+        self.profile = workflow.profile
+        self.location_id = context.get("location_id", None)
+        self.course_id = context.get("course_id", None)
+
+    def _emit_workflow_event(self, event_name: str) -> None:
+        """
+        Emit an xAPI event for this workflow.
+
+        Args:
+            event_name: The event name constant (e.g., EVENT_NAME_WORKFLOW_COMPLETED)
+        """
+
+        tracker.emit(event_name, {
+            "workflow_id": str(self.workflow.id),
+            "action": self.workflow.action,
+            "course_id": str(self.course_id),
+            "profile_name": self.profile.slug,
+            "location_id": str(self.location_id),
+        })
+
+    def run(self, input_data):
+        raise NotImplementedError("Subclasses must implement run method")
+
+    @classmethod
+    def get_orchestrator(cls, *, workflow, user, context):
+        """
+        Resolve and instantiate an orchestrator for the given workflow.
+
+        This factory method centralizes orchestrator lookup and validation.
+        It ensures that the resolved class exists and is a subclass of
+        BaseOrchestrator, providing a single, consistent entry point
+        for orchestrator creation across the codebase.
+
+        Args:
+            workflow: AIWorkflowScope instance that defines the workflow configuration.
+            user: User for whom the workflow is being executed.
+            context: Dictionary with runtime context (e.g. course_id, location_id).
+
+        Returns:
+            BaseOrchestrator: An instantiated orchestrator for the given workflow.
+
+        Raises:
+            AttributeError: If the configured orchestrator class cannot be found.
+            TypeError: If the resolved class is not a subclass of BaseOrchestrator.
+        """
+        orchestrator_name = workflow.profile.orchestrator_class
+        module_path = "openedx_ai_extensions.workflows.orchestrators.orchestrators"
+
+        try:
+            module = importlib.import_module(module_path)
+            orchestrator_class = getattr(module, orchestrator_name)
+        except ImportError as exc:
+            raise ImportError(
+                f"Could not import module '{module_path}' for orchestrator '{orchestrator_name}'"
+            ) from exc
+        except AttributeError as exc:
+            raise AttributeError(
+                f"Orchestrator class '{orchestrator_name}' not found in module '{module_path}'"
+            ) from exc
+        if not issubclass(orchestrator_class, BaseOrchestrator):
+            raise TypeError(
+                f"{orchestrator_name} is not a subclass of BaseOrchestrator"
+            )
+
+        return orchestrator_class(
+            workflow=workflow,
+            user=user,
+            context=context,
+        )

--- a/backend/openedx_ai_extensions/workflows/orchestrators/orchestrators.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/orchestrators.py
@@ -206,37 +206,6 @@ class EducatorAssistantOrchestrator(SessionBasedOrchestrator):
             }
         }
 
-    def get_run_status(self, input_data):  # pylint: disable=unused-argument
-        """
-        Get the status of an async task from session metadata.
-
-        Returns:
-            dict: Status information including task result if completed
-        """
-        metadata = self.session.metadata or {}
-        task_status = metadata.get('task_status', 'processing')
-
-        if task_status == 'completed':
-            return metadata.get('task_result', {
-                'status': 'completed',
-                'message': 'Task completed but no result found'
-            })
-        elif task_status == 'error':
-            return {
-                'status': 'error',
-                'error': metadata.get('task_error', 'Unknown error occurred')
-            }
-        elif task_status == 'timeout':
-            return {
-                'status': 'timeout',
-                'error': metadata.get('task_error', 'Task exceeded time limit')
-            }
-        else:
-            return {
-                'status': 'processing',
-                'message': 'AI workflow is running'
-            }
-
 
 class ThreadedLLMResponse(SessionBasedOrchestrator):
     """

--- a/backend/openedx_ai_extensions/workflows/orchestrators/orchestrators.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/orchestrators.py
@@ -4,20 +4,13 @@ Base classes to hold the logic of execution in ai workflows
 """
 import json
 import logging
-import sys
 import time
-from typing import TYPE_CHECKING
-
-from celery import shared_task
-from celery.exceptions import SoftTimeLimitExceeded
-from eventtracking import tracker
 
 from openedx_ai_extensions.processors import (
     ContentLibraryProcessor,
     EducatorAssistantProcessor,
     LLMProcessor,
     OpenEdXProcessor,
-    SubmissionProcessor,
 )
 from openedx_ai_extensions.utils import is_generator
 from openedx_ai_extensions.xapi.constants import (
@@ -26,170 +19,10 @@ from openedx_ai_extensions.xapi.constants import (
     EVENT_NAME_WORKFLOW_INTERACTED,
 )
 
-if TYPE_CHECKING:
-    from openedx_ai_extensions.workflows.models import AIWorkflow, AIWorkflowSession
+from .base_orchestrator import BaseOrchestrator
+from .session_based_orchestrator import SessionBasedOrchestrator
 
 logger = logging.getLogger(__name__)
-
-
-@shared_task(
-    name="openedx_ai_extensions.workflows.execute_orchestrator",
-    bind=True,
-    time_limit=300,
-    soft_time_limit=270
-)
-def _execute_orchestrator_async(task_self, session_id, action, params=None):
-    """
-    Execute an orchestrator action asynchronously.
-
-    Args:
-        task_self: Celery task instance (bound)
-        session_id: UUID of the AIWorkflowSession
-        action: Method name to call on the orchestrator (e.g., 'run')
-        params: Dictionary of parameters to pass to the action method
-
-    Returns:
-        Result from the orchestrator action method
-    """
-    from openedx_ai_extensions.workflows.models import AIWorkflowSession  # pylint: disable=import-outside-toplevel
-
-    task_id = task_self.request.id
-    params = params or {}
-
-    try:
-        # 1. Get the session from the database
-        session = AIWorkflowSession.objects.select_related('scope', 'profile', 'user').get(id=session_id)
-
-        # 2. Build context from session
-        context = {
-            'course_id': str(session.course_id),
-            'location_id': str(session.location_id),
-        }
-
-        # 3. Resolve and instantiate orchestrator via centralized factory
-        orchestrator_name = session.profile.orchestrator_class
-        try:
-            orchestrator = BaseOrchestrator.get_orchestrator(
-                workflow=session.scope,
-                user=session.user,
-                context=context,
-            )
-        except (AttributeError, TypeError) as exc:
-            logger.error(
-                f"Task {task_id}: Failed to resolve orchestrator: {exc}",
-                exc_info=True,
-            )
-            raise
-
-        # 4. Validate action exists
-        if not hasattr(orchestrator, action):
-            error_msg = f"Orchestrator '{orchestrator_name}' does not have method '{action}'"
-            logger.error(f"Task {task_id}: {error_msg}")
-            raise AttributeError(error_msg)
-
-        # 5. Call the action method with params
-        orchestrator_method = getattr(orchestrator, action)
-        logger.info(f"Task {task_id}: Executing {orchestrator_name}.{action} for session {session_id}")
-        result = orchestrator_method(**params)
-
-        # 6. Update session metadata with result
-        session.metadata['task_result'] = result
-        session.metadata['task_status'] = 'completed'
-        session.save(update_fields=['metadata'])
-
-        logger.info(f"Task {task_id}: Completed successfully")
-        return result
-
-    except SoftTimeLimitExceeded:
-        logger.error(f"Task {task_id}: Soft time limit exceeded for session {session_id}")
-        session.metadata['task_status'] = 'timeout'
-        session.metadata['task_error'] = 'Task exceeded time limit'
-        session.save(update_fields=['metadata'])
-        raise
-
-    except AIWorkflowSession.DoesNotExist:
-        logger.error(f"Task {task_id}: Session {session_id} not found")
-        raise
-
-    except Exception as e:
-        logger.error(f"Task {task_id}: Error executing {action} for session {session_id}: {str(e)}")
-        session.metadata['task_status'] = 'error'
-        session.metadata['task_error'] = str(e)
-        session.save(update_fields=['metadata'])
-        raise
-
-
-class BaseOrchestrator:
-    """Base class for workflow orchestrators."""
-
-    def __init__(self, workflow, user, context):
-        self.workflow = workflow
-        self.user = user
-        self.profile = workflow.profile
-        self.location_id = context.get("location_id", None)
-        self.course_id = context.get("course_id", None)
-
-    def _emit_workflow_event(self, event_name: str) -> None:
-        """
-        Emit an xAPI event for this workflow.
-
-        Args:
-            event_name: The event name constant (e.g., EVENT_NAME_WORKFLOW_COMPLETED)
-        """
-
-        tracker.emit(event_name, {
-            "workflow_id": str(self.workflow.id),
-            "action": self.workflow.action,
-            "course_id": str(self.course_id),
-            "profile_name": self.profile.slug,
-            "location_id": str(self.location_id),
-        })
-
-    def run(self, input_data):
-        raise NotImplementedError("Subclasses must implement run method")
-
-    @classmethod
-    def get_orchestrator(cls, *, workflow, user, context):
-        """
-        Resolve and instantiate an orchestrator for the given workflow.
-
-        This factory method centralizes orchestrator lookup and validation.
-        It ensures that the resolved class exists and is a subclass of
-        BaseOrchestrator, providing a single, consistent entry point
-        for orchestrator creation across the codebase.
-
-        Args:
-            workflow: AIWorkflowScope instance that defines the workflow configuration.
-            user: User for whom the workflow is being executed.
-            context: Dictionary with runtime context (e.g. course_id, location_id).
-
-        Returns:
-            BaseOrchestrator: An instantiated orchestrator for the given workflow.
-
-        Raises:
-            AttributeError: If the configured orchestrator class cannot be found.
-            TypeError: If the resolved class is not a subclass of BaseOrchestrator.
-        """
-        orchestrator_name = workflow.profile.orchestrator_class
-
-        try:
-            module = sys.modules[__name__]
-            orchestrator_class = getattr(module, orchestrator_name)
-        except AttributeError as exc:
-            raise AttributeError(
-                f"Orchestrator class '{orchestrator_name}' not found"
-            ) from exc
-
-        if not issubclass(orchestrator_class, BaseOrchestrator):
-            raise TypeError(
-                f"{orchestrator_name} is not a subclass of BaseOrchestrator"
-            )
-
-        return orchestrator_class(
-            workflow=workflow,
-            user=user,
-            context=context,
-        )
 
 
 class MockResponse(BaseOrchestrator):
@@ -300,36 +133,6 @@ class DirectLLMResponse(BaseOrchestrator):
         return response_data
 
 
-class SessionBasedOrchestrator(BaseOrchestrator):
-    """Orchestrator that provides session-based LLM responses."""
-
-    def __init__(self, workflow, user, context):
-        from openedx_ai_extensions.workflows.models import AIWorkflowSession  # pylint: disable=import-outside-toplevel
-
-        super().__init__(workflow, user, context)
-        self.session, _ = AIWorkflowSession.objects.get_or_create(
-            user=self.user,
-            scope=self.workflow,
-            profile=self.workflow.profile,
-            defaults={},
-        )
-
-    def clear_session(self, _):
-        self.session.delete()
-        return {
-            "response": "",
-            "status": "session_cleared",
-        }
-
-    def _get_submission_processor(self):
-        return SubmissionProcessor(
-            self.profile.processor_config, self.session
-        )
-
-    def run(self, input_data):
-        raise NotImplementedError("Subclasses must implement run method")
-
-
 class EducatorAssistantOrchestrator(SessionBasedOrchestrator):
     """
     Orchestrator for educator assistant workflows.
@@ -401,32 +204,6 @@ class EducatorAssistantOrchestrator(SessionBasedOrchestrator):
                 'tokens_used': llm_result.get('tokens_used'),
                 'model_used': llm_result.get('model_used')
             }
-        }
-
-    def run_async(self, input_data):
-        """
-        Launch async task to execute the run method.
-
-        Args:
-            input_data: Input data to pass to the run method
-        """
-
-        self.session.course_id = self.course_id
-        self.session.location_id = self.location_id
-        self.session.save()
-
-        task = _execute_orchestrator_async.delay(
-            session_id=self.session.id,
-            action='run',
-            params={
-                "input_data": input_data,
-            }
-        )
-
-        return {
-            'status': 'processing',
-            'task_id': task.id,
-            'message': 'AI workflow has started'
         }
 
     def get_run_status(self, input_data):  # pylint: disable=unused-argument

--- a/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
@@ -153,3 +153,34 @@ class SessionBasedOrchestrator(BaseOrchestrator):
             'task_id': task.id,
             'message': 'AI workflow has started'
         }
+
+    def get_run_status(self, input_data):  # pylint: disable=unused-argument
+        """
+        Get the status of an async task from session metadata.
+
+        Returns:
+            dict: Status information including task result if completed
+        """
+        metadata = self.session.metadata or {}
+        task_status = metadata.get('task_status', 'processing')
+
+        if task_status == 'completed':
+            return metadata.get('task_result', {
+                'status': 'completed',
+                'message': 'Task completed but no result found'
+            })
+        elif task_status == 'error':
+            return {
+                'status': 'error',
+                'error': metadata.get('task_error', 'Unknown error occurred')
+            }
+        elif task_status == 'timeout':
+            return {
+                'status': 'timeout',
+                'error': metadata.get('task_error', 'Task exceeded time limit')
+            }
+        else:
+            return {
+                'status': 'processing',
+                'message': 'AI workflow is running'
+            }

--- a/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
@@ -43,8 +43,8 @@ def _execute_orchestrator_async(task_self, session_id, action, params=None):
 
         # 2. Build context from session
         context = {
-            'course_id': str(session.course_id),
-            'location_id': str(session.location_id),
+            'course_id': str(session.course_id) if session.course_id is not None else None,
+            'location_id': str(session.location_id) if session.location_id is not None else None,
         }
 
         # 3. Resolve and instantiate orchestrator via centralized factory
@@ -138,6 +138,10 @@ class SessionBasedOrchestrator(BaseOrchestrator):
 
         self.session.course_id = self.course_id
         self.session.location_id = self.location_id
+        self.session.metadata = self.session.metadata or {}
+        self.session.metadata['task_status'] = 'processing'
+        self.session.metadata.pop('task_result', None)
+        self.session.metadata.pop('task_error', None)
         self.session.save()
 
         task = _execute_orchestrator_async.delay(

--- a/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
@@ -1,0 +1,155 @@
+"""
+Session-based orchestrator.
+"""
+import logging
+
+from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+
+from openedx_ai_extensions.processors import SubmissionProcessor
+from openedx_ai_extensions.workflows.models import AIWorkflowSession
+
+from .base_orchestrator import BaseOrchestrator
+
+logger = logging.getLogger(__name__)
+
+
+@shared_task(
+    name="openedx_ai_extensions.workflows.execute_orchestrator",
+    bind=True,
+    time_limit=300,
+    soft_time_limit=270
+)
+def _execute_orchestrator_async(task_self, session_id, action, params=None):
+    """
+    Execute an orchestrator action asynchronously.
+
+    Args:
+        task_self: Celery task instance (bound)
+        session_id: UUID of the AIWorkflowSession
+        action: Method name to call on the orchestrator (e.g., 'run')
+        params: Dictionary of parameters to pass to the action method
+
+    Returns:
+        Result from the orchestrator action method
+    """
+
+    task_id = task_self.request.id
+    params = params or {}
+
+    try:
+        # 1. Get the session from the database
+        session = AIWorkflowSession.objects.select_related('scope', 'profile', 'user').get(id=session_id)
+
+        # 2. Build context from session
+        context = {
+            'course_id': str(session.course_id),
+            'location_id': str(session.location_id),
+        }
+
+        # 3. Resolve and instantiate orchestrator via centralized factory
+        orchestrator_name = session.profile.orchestrator_class
+        try:
+            orchestrator = BaseOrchestrator.get_orchestrator(
+                workflow=session.scope,
+                user=session.user,
+                context=context,
+            )
+        except (AttributeError, TypeError) as exc:
+            logger.error(
+                f"Task {task_id}: Failed to resolve orchestrator: {exc}",
+                exc_info=True,
+            )
+            raise
+
+        # 4. Validate action exists
+        if not hasattr(orchestrator, action):
+            error_msg = f"Orchestrator '{orchestrator_name}' does not have method '{action}'"
+            logger.error(f"Task {task_id}: {error_msg}")
+            raise AttributeError(error_msg)
+
+        # 5. Call the action method with params
+        orchestrator_method = getattr(orchestrator, action)
+        logger.info(f"Task {task_id}: Executing {orchestrator_name}.{action} for session {session_id}")
+        result = orchestrator_method(**params)
+
+        # 6. Update session metadata with result
+        session.metadata['task_result'] = result
+        session.metadata['task_status'] = 'completed'
+        session.save(update_fields=['metadata'])
+
+        logger.info(f"Task {task_id}: Completed successfully")
+        return result
+
+    except SoftTimeLimitExceeded:
+        logger.error(f"Task {task_id}: Soft time limit exceeded for session {session_id}")
+        session.metadata['task_status'] = 'timeout'
+        session.metadata['task_error'] = 'Task exceeded time limit'
+        session.save(update_fields=['metadata'])
+        raise
+
+    except AIWorkflowSession.DoesNotExist:
+        logger.error(f"Task {task_id}: Session {session_id} not found")
+        raise
+
+    except Exception as e:
+        logger.error(f"Task {task_id}: Error executing {action} for session {session_id}: {str(e)}")
+        session.metadata['task_status'] = 'error'
+        session.metadata['task_error'] = str(e)
+        session.save(update_fields=['metadata'])
+        raise
+
+
+class SessionBasedOrchestrator(BaseOrchestrator):
+    """Orchestrator that provides session-based LLM responses."""
+
+    def __init__(self, workflow, user, context):
+
+        super().__init__(workflow, user, context)
+        self.session, _ = AIWorkflowSession.objects.get_or_create(
+            user=self.user,
+            scope=self.workflow,
+            profile=self.workflow.profile,
+            defaults={},
+        )
+
+    def clear_session(self, _):
+        self.session.delete()
+        return {
+            "response": "",
+            "status": "session_cleared",
+        }
+
+    def _get_submission_processor(self):
+        return SubmissionProcessor(
+            self.profile.processor_config, self.session
+        )
+
+    def run(self, input_data):
+        raise NotImplementedError("Subclasses must implement run method")
+
+    def run_async(self, input_data):
+        """
+        Launch async task to execute the run method.
+
+        Args:
+            input_data: Input data to pass to the run method
+        """
+
+        self.session.course_id = self.course_id
+        self.session.location_id = self.location_id
+        self.session.save()
+
+        task = _execute_orchestrator_async.delay(
+            session_id=self.session.id,
+            action='run',
+            params={
+                "input_data": input_data,
+            }
+        )
+
+        return {
+            'status': 'processing',
+            'task_id': task.id,
+            'message': 'AI workflow has started'
+        }

--- a/backend/openedx_ai_extensions/workflows/template_utils.py
+++ b/backend/openedx_ai_extensions/workflows/template_utils.py
@@ -13,6 +13,8 @@ from django.conf import settings
 from jsonmerge import merge
 from jsonschema import Draft7Validator
 
+from openedx_ai_extensions.models import PromptTemplate
+
 logger = logging.getLogger(__name__)
 
 
@@ -351,7 +353,6 @@ def _validate_prompt_templates(processor_config: dict) -> list[str]:
     Returns:
         List of error messages for any missing prompt templates.
     """
-    from openedx_ai_extensions.models import PromptTemplate  # pylint: disable=import-outside-toplevel
 
     errors = []
 

--- a/backend/tests/test_base_orchestrator.py
+++ b/backend/tests/test_base_orchestrator.py
@@ -75,7 +75,7 @@ def test_base_orchestrator_init(mock_workflow, mock_user):  # pylint: disable=re
 # ============================================================================
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.tracker")
+@patch("openedx_ai_extensions.workflows.orchestrators.base_orchestrator.tracker")
 def test_emit_workflow_event(mock_tracker, mock_workflow, mock_user):  # pylint: disable=redefined-outer-name
     """
     Test that _emit_workflow_event calls tracker.emit with correct payload.
@@ -117,7 +117,7 @@ def test_get_orchestrator_success(monkeypatch, mock_workflow, mock_user):  # pyl
     """
     Test get_orchestrator returns an instance of the resolved class.
     """
-    from openedx_ai_extensions.workflows import orchestrators  # pylint: disable=import-outside-toplevel
+    from openedx_ai_extensions.workflows.orchestrators import orchestrators  # pylint: disable=import-outside-toplevel
 
     class MockOrchestrator(BaseOrchestrator):
         def run(self, input_data):
@@ -156,7 +156,7 @@ def test_get_orchestrator_type_error(monkeypatch, mock_workflow, mock_user):  # 
     """
     Test get_orchestrator raises TypeError when resolved class is not a subclass of BaseOrchestrator.
     """
-    from openedx_ai_extensions.workflows import orchestrators  # pylint: disable=import-outside-toplevel
+    from openedx_ai_extensions.workflows.orchestrators import orchestrators  # pylint: disable=import-outside-toplevel
 
     class NotAnOrchestrator:
         pass

--- a/backend/tests/test_workflows.py
+++ b/backend/tests/test_workflows.py
@@ -11,17 +11,9 @@ from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator
 
-# Mock the submissions module before any imports that depend on it
-sys.modules["submissions"] = MagicMock()
-sys.modules["submissions.api"] = MagicMock()
-
-from openedx_ai_extensions.workflows.models import (  # noqa: E402 pylint: disable=wrong-import-position
-    AIWorkflowProfile,
-    AIWorkflowScope,
-    AIWorkflowSession,
-)
-from openedx_ai_extensions.workflows.orchestrators import (  # noqa: E402 pylint: disable=wrong-import-position
-    BaseOrchestrator,
+from openedx_ai_extensions.workflows.models import AIWorkflowProfile, AIWorkflowScope, AIWorkflowSession
+from openedx_ai_extensions.workflows.orchestrators import BaseOrchestrator
+from openedx_ai_extensions.workflows.orchestrators.orchestrators import (
     DirectLLMResponse,
     MockResponse,
     MockStreamResponse,
@@ -29,6 +21,10 @@ from openedx_ai_extensions.workflows.orchestrators import (  # noqa: E402 pylint
 )
 
 User = get_user_model()
+
+# Mock the submissions module before any imports that depend on it
+sys.modules["submissions"] = MagicMock()
+sys.modules["submissions.api"] = MagicMock()
 
 
 @pytest.fixture
@@ -165,7 +161,7 @@ def test_workflow_scope_execute(workflow_scope, user):  # pylint: disable=redefi
         del workflow_scope.profile._config
 
     # Mock the orchestrator
-    with patch("openedx_ai_extensions.workflows.orchestrators.MockResponse") as mock_orch:
+    with patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.MockResponse") as mock_orch:
         mock_instance = Mock()
         mock_instance.run = Mock(return_value={"status": "completed", "response": "Test"})
         mock_orch.return_value = mock_instance
@@ -352,8 +348,8 @@ def test_mock_stream_response_orchestrator(workflow_scope, user):  # pylint: dis
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.OpenEdXProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
 def test_direct_llm_response_orchestrator_success(
     mock_llm_processor_class,
     mock_openedx_processor_class,
@@ -394,7 +390,7 @@ def test_direct_llm_response_orchestrator_success(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.OpenEdXProcessor")
 def test_direct_llm_response_orchestrator_openedx_error(
     mock_openedx_processor_class,
     workflow_scope,  # pylint: disable=redefined-outer-name
@@ -418,8 +414,8 @@ def test_direct_llm_response_orchestrator_openedx_error(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.OpenEdXProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
 def test_direct_llm_response_orchestrator_llm_error(
     mock_llm_processor_class,
     mock_openedx_processor_class,
@@ -448,9 +444,9 @@ def test_direct_llm_response_orchestrator_llm_error(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.OpenEdXProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.SubmissionProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator.SubmissionProcessor")
 def test_threaded_llm_response_orchestrator_new_session(
     mock_submission_processor_class,
     mock_responses_processor_class,
@@ -493,8 +489,8 @@ def test_threaded_llm_response_orchestrator_new_session(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.SubmissionProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator.SubmissionProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
 def test_threaded_llm_response_orchestrator_clear_session(
     mock_responses_processor_class,
     mock_submission_processor_class,
@@ -531,8 +527,8 @@ def test_threaded_llm_response_orchestrator_clear_session(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.SubmissionProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator.SubmissionProcessor")
 def test_threaded_llm_response_orchestrator_get_history(
     mock_submission_processor_class,
     mock_responses_processor_class,
@@ -575,8 +571,8 @@ def test_threaded_llm_response_orchestrator_get_history(
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.workflows.orchestrators.LLMProcessor")
-@patch("openedx_ai_extensions.workflows.orchestrators.SubmissionProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.orchestrators.LLMProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator.SubmissionProcessor")
 def test_threaded_llm_response_orchestrator_history_error(
     mock_submission_processor_class,
     mock_responses_processor_class,


### PR DESCRIPTION
This pull request refactors the orchestrator workflow system to improve modularity, clarity, and maintainability. The main changes involve splitting the orchestrator logic into dedicated modules, moving Celery task definitions, and centralizing the base orchestrator class. Additionally, imports have been cleaned up and tests updated to match the new structure.

**Orchestrator Refactoring and Modularization:**

* The orchestrator logic has been split into separate files: `base_orchestrator.py` for the base class, `session_based_orchestrator.py` for session-based orchestration and Celery task, and `orchestrators.py` for concrete implementations. This improves code organization and separation of concerns.
* The Celery task `_execute_orchestrator_async` and the `SessionBasedOrchestrator` class have been moved from `orchestrators.py` to `session_based_orchestrator.py`, clarifying responsibility for async orchestration. 

`run_async` method was moved from `EducatorOrchestrator` to `SessionBasedOrchestrator`, because of it's implementation relies on sessions, with this change, we also move the capability of run async tasks to any orchestrator based on `SessionBasedOrchestrator`