### PR TITLE
fix: removing the automatic sending of custom message into the chat box

### DIFF
--- a/frontend/src/ConfigurableAIAssistance.tsx
+++ b/frontend/src/ConfigurableAIAssistance.tsx
@@ -196,7 +196,7 @@ const ConfigurableAIAssistance = ({
     } finally {
       setIsLoading(false);
     }
-  }, [config, additionalProps]);
+  }, [additionalProps]);
 
   /**
    * Reset component state for new request

--- a/frontend/src/ConfigurableAIAssistance.tsx
+++ b/frontend/src/ConfigurableAIAssistance.tsx
@@ -153,15 +153,10 @@ const ConfigurableAIAssistance = ({
         ...additionalProps,
       });
 
-      const requestMessage = config?.request.config?.customMessage
-        || config?.request.config?.requestMessage
-        || null;
-
       let buffer = '';
       // Make API call
       const data = await callWorkflowService({
         context: contextData,
-        userInput: requestMessage,
         payload: {
           action: WORKFLOW_ACTIONS.RUN,
           requestId: `ai-request-${Date.now()}`,

--- a/frontend/src/GetAIAssistanceButton.tsx
+++ b/frontend/src/GetAIAssistanceButton.tsx
@@ -100,7 +100,7 @@ const GetAIAssistanceButton = ({
     } finally {
       setIsLoading(false);
     }
-  }, [requestMessage, props]);
+  }, [props]);
 
   /**
    * Reset component state for new request

--- a/frontend/src/GetAIAssistanceButton.tsx
+++ b/frontend/src/GetAIAssistanceButton.tsx
@@ -56,7 +56,6 @@ const GetAIAssistanceButton = ({
       // Make API call with flexible parameters
       const data = await callWorkflowService({
         context: contextData,
-        userInput: requestMessage || 'Provide learning assistance for this content',
         payload: {
           action: WORKFLOW_ACTIONS.SIMPLE_BUTTON_ASSISTANCE,
           requestId: `ai-request-${Date.now()}`,


### PR DESCRIPTION
This PR fixes a regression introduced with the typescript refactoring.

After the refactor, the button that opens the chat would also insert the custom text from the request component into the chat window as a user message. This is wrong and it would prevent the previous messages from being loaded.