### PR TITLE
fix: when streaming, closing the chat window will continue to capture focus and reopen the chat div

### DIFF
--- a/frontend/src/ConfigurableAIAssistance.tsx
+++ b/frontend/src/ConfigurableAIAssistance.tsx
@@ -114,6 +114,7 @@ const ConfigurableAIAssistance = ({
   const [response, setResponse] = useState('');
   const [error, setError] = useState('');
   const [hasAsked, setHasAsked] = useState(false);
+  const [openSidebarSignal, setOpenSidebarSignal] = useState(0);
 
   const configEndpoint = getDefaultEndpoint('profile');
   const requestIdRef = useRef(0);
@@ -244,6 +245,10 @@ const ConfigurableAIAssistance = ({
     }
   }, [additionalProps]);
 
+  const handleOpenSidebar = useCallback(() => {
+    setOpenSidebarSignal((prev) => prev + 1);
+  }, []);
+
   /**
    * Reset component state for new request
    */
@@ -361,6 +366,7 @@ const ConfigurableAIAssistance = ({
           setResponse={setResponse}
           setHasAsked={setHasAsked}
           onAskAI={handleAskAI}
+          onOpenSidebar={handleOpenSidebar}
           disabled={false}
           {...requestProps}
         />
@@ -374,6 +380,7 @@ const ConfigurableAIAssistance = ({
           onClear={handleReset}
           onError={handleClearError}
           contextData={additionalProps}
+          openSidebarSignal={openSidebarSignal}
           {...responseProps}
         />
       </div>

--- a/frontend/src/components/AIRequestComponent.tsx
+++ b/frontend/src/components/AIRequestComponent.tsx
@@ -13,6 +13,7 @@ interface AIRequestComponentProps {
   isLoading: boolean;
   hasAsked: boolean;
   onAskAI: () => void;
+  onOpenSidebar?: () => void;
   customMessage?: string;
   buttonText?: string;
   disabled: boolean;
@@ -22,6 +23,7 @@ const AIRequestComponent = ({
   isLoading,
   hasAsked,
   onAskAI,
+  onOpenSidebar,
   customMessage,
   buttonText,
   disabled = false,
@@ -31,10 +33,7 @@ const AIRequestComponent = ({
   const displayMessage = customMessage || intl.formatMessage(messages['ai.extensions.request.default.message']);
   const displayButtonText = buttonText || intl.formatMessage(messages['ai.extensions.request.default.button']);
 
-  // Don't render if already asked or currently loading
-  if (hasAsked && !isLoading) {
-    return null;
-  }
+  const shouldShowOpenButton = hasAsked && !isLoading && typeof onOpenSidebar === 'function';
 
   return (
     <div className="ai-request-container">
@@ -63,6 +62,25 @@ const AIRequestComponent = ({
             variant="primary"
             size="sm"
             onClick={onAskAI}
+            disabled={disabled || isLoading}
+            iconBefore={Send}
+            className="rounded-pill"
+          >
+            {displayButtonText}
+          </Button>
+        </div>
+      )}
+
+      {/* Re-open sidebar state (keep original button available) */}
+      {shouldShowOpenButton && (
+        <div className="d-flex align-items-center justify-content-end py-2">
+          <span className="text-muted mr-3 small">
+            {displayMessage}
+          </span>
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={onOpenSidebar}
             disabled={disabled || isLoading}
             iconBefore={Send}
             className="rounded-pill"


### PR DESCRIPTION
Related issue:  https://github.com/openedx/openedx-ai-extensions/issues/134

## Summary

Improves the AI Sidebar chat UX during **streaming responses** by preventing scroll “hijacking” and allowing the sidebar to be closed by clicking outside.

## Problem

When the AI response is streamed in many incremental chunks, the UI could:

- Force-scroll to the bottom on every chunk, preventing users from scrolling up to read previous messages.
- Feel “kidnapped” because the view kept snapping down while the message was being generated.
- Not reliably close when clicking outside the sidebar during streaming.

## Changes (Frontend)

### 1) Smart auto-follow (no scroll hijacking)
- Tracks whether the user is near the bottom and whether auto-follow is enabled.
- If the user scrolls up (even slightly), auto-follow is disabled immediately.
- Auto-follow is re-enabled only when the user scrolls back near the bottom.
- Ignores programmatic scroll events to avoid feedback loops.

### 2) Close on outside click (backdrop click)
- Uses `ModalLayer`'s `onClose` to close the sidebar when the user clicks outside the sidebar area.
- Closing the sidebar does not fight against streaming updates.

## How it works

- Auto-scroll occurs only when:
  - the user is near the bottom, and
  - auto-follow is enabled.
- A user scroll-up disables auto-follow so streaming chunks no longer yank the viewport back down.
- Clicking outside triggers `onClose` -> `handleClose`, closing the sidebar cleanly.

## What this prevents

- Forced auto-scroll during streaming (scroll hijacking).
- Scroll event feedback loops caused by programmatic scrolling.
- Being unable to dismiss the sidebar via outside click while content is streaming.

## Testing


https://github.com/user-attachments/assets/d42a9570-2a0d-4598-87a7-398d5b4fef97

