### PR TITLE
feat: add public call completion method

### DIFF
--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -512,3 +512,11 @@ class LLMProcessor(LitellmProcessor):
                     "content": f"{getattr(item, 'name', '?')}({getattr(item, 'arguments', '')})",
                 })
         return items
+
+    def call_completion(self, context, system_role):
+        """
+        Public method to call completion with a given system role.
+        Returns either a generator (if stream=True) or a response dict.
+        """
+        self.context = context
+        return self._call_completion_wrapper(system_role=system_role)


### PR DESCRIPTION
This pull request introduces a new public method to the `llm_processor.py` file, providing a cleaner interface for calling completions with a specified system role.

Enhancements to LLM completion interface:

* Added a `call_completion` method to the `LLMProcessor` class, allowing users to invoke completions with a given `context` and `system_role`, and returning either a generator or a response dictionary depending on the streaming flag.

The idea of this new method is allow extension to use completion without the needed of create Processors.