### PR TITLE
feat: add the get_course_info function to openedx processor

### DIFF
--- a/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
@@ -314,8 +314,12 @@ class OpenEdXProcessor:
         "function": {
             "name": "get_course_info",
             "description": (
-                "Retrieve course metadata. Use the 'fields' parameter to include the "
-                "'outline' if course structure is needed."
+                "Retrieve course-level metadata including title, subtitle, descriptions, overview, "
+                "syllabus, duration, and optionally the hierarchical course structure (sections -> "
+                "subsections -> units). Use this to understand what a course is about, provide summaries, "
+                "explain organization, or navigate structure. By default returns all fields except 'outline'. "
+                "The 'outline' must be explicitly requested and returns hierarchical JSON. "
+                "For actual unit content (text, problems, videos), use get_location_content instead."
             ),
             "parameters": {
                 "type": "object",

--- a/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
@@ -388,7 +388,7 @@ class OpenEdXProcessor:
             course_details = CourseDetails.fetch(course_key)
             course_block = modulestore().get_course(course_key)
 
-            requested_fields = fields or self.config.get("fields")
+            requested_fields = fields if fields is not None else self.config.get("fields")
 
             full_info = {
                 "title": str(course_block.display_name or ""),
@@ -400,8 +400,8 @@ class OpenEdXProcessor:
                 "duration": str(course_details.duration or ""),
             }
 
-            if not requested_fields or "outline" in requested_fields:
-                full_info["outline"] = str(self.get_course_outline(course_id=course_id) or "")
+            if requested_fields and "outline" in requested_fields:
+                full_info["outline"] = self.get_course_outline(course_id=course_id)
 
             # Filter response
             if requested_fields:

--- a/backend/tests/test_openedx_processor.py
+++ b/backend/tests/test_openedx_processor.py
@@ -29,6 +29,11 @@ def mock_edx_imports():
         "lms.djangoapps": MagicMock(),
         "lms.djangoapps.course_blocks": MagicMock(),
         "lms.djangoapps.course_blocks.api": MagicMock(),
+        "openedx": MagicMock(),
+        "openedx.core": MagicMock(),
+        "openedx.core.djangoapps": MagicMock(),
+        "openedx.core.djangoapps.models": MagicMock(),
+        "openedx.core.djangoapps.models.course_details": MagicMock(),
     }):
         yield
 
@@ -339,3 +344,136 @@ def test_process_defaults_to_no_context(processor):
 
         mock_no_context.assert_called_once_with("arg1")
         assert result == "default_response"
+
+
+# ============================================================================
+# Tests: Course Info
+# ============================================================================
+
+def test_get_course_info_all_fields(mock_edx_imports, mock_keys):
+    """Test retrieving all course info fields without outline."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from openedx.core.djangoapps.models.course_details import CourseDetails
+    from xmodule.modulestore.django import modulestore
+
+    test_processor = OpenEdXProcessor(course_id="course-v1:org+name+version")
+
+    # Mock CourseDetails
+    mock_details = MagicMock()
+    mock_details.subtitle = "Test Subtitle"
+    mock_details.short_description = "Short description"
+    mock_details.description = "Full description"
+    mock_details.overview = "<p>Overview content</p>"
+    mock_details.syllabus = "Course syllabus"
+    mock_details.duration = "4 weeks"
+    CourseDetails.fetch.return_value = mock_details
+
+    # Mock course block
+    mock_course_block = MagicMock()
+    mock_course_block.display_name = "Test Course"
+    mock_store = modulestore.return_value
+    mock_store.get_course.return_value = mock_course_block
+
+    result = test_processor.get_course_info()
+
+    assert result["title"] == "Test Course"
+    assert result["subtitle"] == "Test Subtitle"
+    assert result["short_description"] == "Short description"
+    assert result["description"] == "Full description"
+    assert result["overview"] == "<p>Overview content</p>"
+    assert result["syllabus"] == "Course syllabus"
+    assert result["duration"] == "4 weeks"
+
+
+def test_get_course_info_specific_fields(mock_edx_imports, mock_keys):
+    """Test retrieving only specific course info fields."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from openedx.core.djangoapps.models.course_details import CourseDetails
+    from xmodule.modulestore.django import modulestore
+
+    test_processor = OpenEdXProcessor(course_id="course-v1:org+name+version")
+
+    mock_details = MagicMock()
+    mock_details.subtitle = "Test Subtitle"
+    mock_details.short_description = "Short description"
+    CourseDetails.fetch.return_value = mock_details
+
+    mock_course_block = MagicMock()
+    mock_course_block.display_name = "Test Course"
+    mock_store = modulestore.return_value
+    mock_store.get_course.return_value = mock_course_block
+
+    result = test_processor.get_course_info(fields=["title", "subtitle"])
+
+    assert result == {"title": "Test Course", "subtitle": "Test Subtitle"}
+    assert "short_description" not in result
+    assert "outline" not in result
+
+
+def test_get_course_info_with_outline(mock_edx_imports, mock_keys):
+    """Test retrieving course info including outline."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from openedx.core.djangoapps.models.course_details import CourseDetails
+    from xmodule.modulestore.django import modulestore
+
+    test_processor = OpenEdXProcessor(course_id="course-v1:org+name+version")
+
+    mock_details = MagicMock()
+    mock_details.subtitle = ""
+    CourseDetails.fetch.return_value = mock_details
+
+    mock_course_block = MagicMock()
+    mock_course_block.display_name = "Test Course"
+    mock_store = modulestore.return_value
+    mock_store.get_course.return_value = mock_course_block
+
+    mock_outline = [{"display_name": "Section 1"}]
+
+    with patch.object(test_processor, 'get_course_outline', return_value=json.dumps(mock_outline)):
+        result = test_processor.get_course_info(fields=["title", "outline"])
+
+    assert result["title"] == "Test Course"
+    assert result["outline"] == json.dumps(mock_outline)
+    assert "subtitle" not in result
+
+
+def test_get_course_info_from_config(mock_edx_imports, mock_keys):
+    """Test that fields can be specified via processor config."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from openedx.core.djangoapps.models.course_details import CourseDetails
+    from xmodule.modulestore.django import modulestore
+
+    config = {"OpenEdXProcessor": {"fields": ["title", "duration"]}}
+    test_processor = OpenEdXProcessor(processor_config=config, course_id="course-v1:org+name+version")
+
+    mock_details = MagicMock()
+    mock_details.duration = "6 weeks"
+    CourseDetails.fetch.return_value = mock_details
+
+    mock_course_block = MagicMock()
+    mock_course_block.display_name = "Test Course"
+    mock_store = modulestore.return_value
+    mock_store.get_course.return_value = mock_course_block
+
+    result = test_processor.get_course_info()
+
+    assert result == {"title": "Test Course", "duration": "6 weeks"}
+
+
+def test_get_course_info_error_handling(mock_edx_imports, mock_keys):
+    """Test that exceptions are caught and returned as errors."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from openedx.core.djangoapps.models.course_details import CourseDetails
+
+    CourseDetails.fetch.side_effect = Exception("Database error")
+
+    test_processor = OpenEdXProcessor(course_id="course-v1:org+name+version")
+    result = test_processor.get_course_info()
+
+    assert "error" in result
+    assert "Database error" in result["error"]

--- a/backend/tests/test_openedx_processor.py
+++ b/backend/tests/test_openedx_processor.py
@@ -384,6 +384,7 @@ def test_get_course_info_all_fields(mock_edx_imports, mock_keys):
     assert result["overview"] == "<p>Overview content</p>"
     assert result["syllabus"] == "Course syllabus"
     assert result["duration"] == "4 weeks"
+    assert "outline" not in result
 
 
 def test_get_course_info_specific_fields(mock_edx_imports, mock_keys):


### PR DESCRIPTION
## Description

This function retrieves the course information.

Related PR: https://github.com/eduNEXT/openedx-ai-badges/pull/6

## How to test

Quick test (without llm request)
1. Create a profile with `examples.openweights.qwen_summary`
1.1 Add a patch
```json
{
  "orchestrator_class": "DirectLLMResponse",
  "processor_config": {
    "OpenEdXProcessor": {
      "function": "get_course_info"
    },
    "LLMProcessor": {
      "function": "summarize_content",
      "provider": "openai"
    }
  }
} 
```
2. Edit the DirectLLMResponse to return the value before calling the LLM.
```python
class DirectLLMResponse(BaseOrchestrator):
    """
    Orchestrator for direct LLM responses.
    Does a single call to an LLM and gives a response.
    """

    def run(self, input_data):
        """
        Executes the content fetching, LLM processing, and handles streaming
        or structured response return.
        """

        # --- 1. Process with OpenEdX processor (Content Fetching) ---
        openedx_processor = OpenEdXProcessor(
            processor_config=self.profile.processor_config,
            location_id=self.location_id,
            course_id=self.course_id,
            user=self.user,
        )
        content_result = openedx_processor.process()

        # 
        # --- This is what we are adding ---
        return {
            'response': str(content_result),
            'status': 'completed'
        }
```
3. Associate the profile with a Scope (it could be LMS or CMS).
4. Interact with the AI component, and you should see a response with the course info.