### PR TITLE
feat: exposing version number in admin

### DIFF
--- a/backend/openedx_ai_extensions/__init__.py
+++ b/backend/openedx_ai_extensions/__init__.py
@@ -2,4 +2,4 @@
 A experimental plugin for Open edX designed to explore AI extensibility.
 """
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"

--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -5,6 +5,8 @@ openedx_ai_extensions Django application initialization.
 from django.apps import AppConfig
 from edx_django_utils.plugins.constants import PluginSettings, PluginSignals, PluginURLs
 
+from openedx_ai_extensions import __version__
+
 
 class OpenedxAIExtensionsConfig(AppConfig):
     # pylint: disable=line-too-long
@@ -17,6 +19,7 @@ class OpenedxAIExtensionsConfig(AppConfig):
 
     default_auto_field = "django.db.models.BigAutoField"
     name = "openedx_ai_extensions"
+    verbose_name = f"Open edX AI Extensions (v{__version__})"
 
     def ready(self):
         """

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/openedx-ai-extensions-ui",
-  "version": "0.0.1",
+  "version": "1.1.0",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
   "repository": {


### PR DESCRIPTION
This PR makes 2 things:

1. it updates the version number for the package.json and the backend/__init__.py
2. it exposes the version in the admin using the verbose name. As an easy way to let admins know which version of the framework they have installed