### PR TITLE
feat: litellm client-side cache implementation

### DIFF
--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -42,36 +42,42 @@ class OpenedxAIExtensionsConfig(AppConfig):
 
     def _configure_llm_cache(self):
         """
-        Initialise the LiteLLM cache backend from ``AI_EXTENSIONS_LLM_CACHE``.
+        Initialise the LiteLLM cache backend.
 
-        The setting is a dict with at least ``{"enabled": True/False}``.
-        Additional keys are forwarded verbatim to ``litellm.Cache(**kwargs)``.
+        Reads ``AI_EXTENSIONS_ENABLE_LLM_CACHE`` (bool) to decide whether to
+        activate caching, and ``AI_EXTENSIONS_LLM_CACHE`` (dict) for backend
+        kwargs forwarded verbatim to ``litellm.Cache(**kwargs)``.
 
         Example (Redis)::
 
+            AI_EXTENSIONS_ENABLE_LLM_CACHE = True
             AI_EXTENSIONS_LLM_CACHE = {
-                "enabled": True,
                 "type": "redis",
                 "host": "localhost",
                 "port": 6379,
             }
         """
+        import litellm  # pylint: disable=import-outside-toplevel
+        from django.conf import settings  # pylint: disable=import-outside-toplevel
+
+        if not getattr(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", False):
+            return
+
+        cache_kwargs = getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {})
         try:
-            import litellm  # pylint: disable=import-outside-toplevel
-            from django.conf import settings  # pylint: disable=import-outside-toplevel
-
-            cache_config = getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {})
-            if not isinstance(cache_config, dict) or not cache_config.get("enabled"):
-                return
-
-            cache_kwargs = {k: v for k, v in cache_config.items() if k != "enabled"}
             litellm.cache = litellm.Cache(**cache_kwargs)
-            logger.info(
-                "LiteLLM cache initialised (type=%s)",
-                cache_kwargs.get("type", "default"),
-            )
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.exception("Failed to initialise LiteLLM cache")
+            logger.exception(
+                "Failed to initialise LiteLLM cache with config=%r; "
+                "caching is disabled. Check AI_EXTENSIONS_LLM_CACHE.",
+                cache_kwargs,
+            )
+            return
+
+        logger.info(
+            "LiteLLM cache initialised (type=%s)",
+            cache_kwargs.get("type", "default"),
+        )
 
     plugin_app = {
         "url_config": {

--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -55,6 +55,7 @@ class OpenedxAIExtensionsConfig(AppConfig):
                 "type": "redis",
                 "host": "localhost",
                 "port": 6379,
+                "ttl": 259200,  # 72 hours
             }
         """
         import litellm  # pylint: disable=import-outside-toplevel

--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -62,7 +62,14 @@ class LitellmProcessor:
                 self.extra_params["tools"] = functions_schema_filtered
 
         cache_option = self.config.get("cache", False)
-        if cache_option and settings.AI_EXTENSIONS_LLM_CACHE.get("enabled", False) is not True:
+        cache_settings = getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {})
+        if not isinstance(cache_settings, dict):
+            logger.warning(
+                "AI_EXTENSIONS_LLM_CACHE setting must be a dict; got %r. Disabling caching.",
+                type(cache_settings).__name__,
+            )
+            cache_settings = {}
+        if cache_option and cache_settings.get("enabled", False) is not True:
             logger.warning("Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching.")
             cache_option = False
         self.extra_params["caching"] = cache_option

--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -72,7 +72,7 @@ class LitellmProcessor:
         if cache_option and cache_settings.get("enabled", False) is not True:
             logger.warning("Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching.")
             cache_option = False
-        self.extra_params["caching"] = cache_option
+        self.caching_enabled = cache_option
 
         self.mcp_configs = {}
         allowed_mcp_configs = self.config.get("mcp_configs", [])

--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -62,15 +62,10 @@ class LitellmProcessor:
                 self.extra_params["tools"] = functions_schema_filtered
 
         cache_option = self.config.get("cache", False)
-        cache_settings = getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {})
-        if not isinstance(cache_settings, dict):
+        if cache_option and not getattr(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", False):
             logger.warning(
-                "AI_EXTENSIONS_LLM_CACHE setting must be a dict; got %r. Disabling caching.",
-                type(cache_settings).__name__,
+                "Caching is disabled in settings. Set AI_EXTENSIONS_ENABLE_LLM_CACHE = True to use caching."
             )
-            cache_settings = {}
-        if cache_option and cache_settings.get("enabled", False) is not True:
-            logger.warning("Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching.")
             cache_option = False
         self.caching_enabled = cache_option
 

--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -61,6 +61,12 @@ class LitellmProcessor:
             if functions_schema_filtered:
                 self.extra_params["tools"] = functions_schema_filtered
 
+        cache_option = self.config.get("cache", False)
+        if cache_option and settings.AI_EXTENSIONS_LLM_CACHE.get("enabled", False) is not True:
+            logger.warning("Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching.")
+            cache_option = False
+        self.extra_params["caching"] = cache_option
+
         self.mcp_configs = {}
         allowed_mcp_configs = self.config.get("mcp_configs", [])
         if allowed_mcp_configs:

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -210,8 +210,9 @@ class LLMProcessor(LitellmProcessor):
             "messages": [
                 {"role": "system", "content": self.custom_prompt or system_role},
             ],
-            "caching": self.caching_enabled,
         }
+        if self.caching_enabled:
+            params["caching"] = True
 
         if self.context:
             params["messages"].append(

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -210,6 +210,7 @@ class LLMProcessor(LitellmProcessor):
             "messages": [
                 {"role": "system", "content": self.custom_prompt or system_role},
             ],
+            "caching": self.caching_enabled,
         }
 
         if self.context:

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -74,6 +74,26 @@ def plugin_settings(settings):
         settings.AI_EXTENSIONS_MAX_CONTEXT_MESSAGES = 3
 
     # -------------------------
+    # Caching
+    # -------------------------
+    # Configure the LiteLLM cache backend.  Set `enabled: True` and provide
+    # backend-specific params (type, host, port, …) to activate LLM-level
+    # caching (identical prompt+model pairs are served from cache).
+    #
+    # Supported types mirror LiteLLM: "redis", "redis-semantic", "s3",
+    # "disk", "in-memory".
+    #
+    # Example for Redis:
+    #   AI_EXTENSIONS_LLM_CACHE = {
+    #       "enabled": True,
+    #       "type": "redis",
+    #       "host": "localhost",
+    #       "port": 6379,
+    #   }
+    if not hasattr(settings, "AI_EXTENSIONS_LLM_CACHE"):
+        settings.AI_EXTENSIONS_LLM_CACHE = {"enabled": False}
+
+    # -------------------------
     # Default field filters
     # -------------------------
     if not hasattr(settings, "AI_EXTENSIONS_FIELD_FILTERS"):

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -89,6 +89,7 @@ def plugin_settings(settings):
     #       "type": "redis",
     #       "host": "localhost",
     #       "port": 6379,
+    #       "ttl": 259200,  # 72 hours
     #   }
     if not hasattr(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE"):
         settings.AI_EXTENSIONS_ENABLE_LLM_CACHE = False

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -76,22 +76,24 @@ def plugin_settings(settings):
     # -------------------------
     # Caching
     # -------------------------
-    # Configure the LiteLLM cache backend.  Set `enabled: True` and provide
-    # backend-specific params (type, host, port, …) to activate LLM-level
-    # caching (identical prompt+model pairs are served from cache).
+    # Toggle LLM-level response caching (identical prompt+model pairs served
+    # from cache).  Set AI_EXTENSIONS_ENABLE_LLM_CACHE = True to activate,
+    # then configure the backend via AI_EXTENSIONS_LLM_CACHE.
     #
     # Supported types mirror LiteLLM: "redis", "redis-semantic", "s3",
     # "disk", "in-memory".
     #
     # Example for Redis:
+    #   AI_EXTENSIONS_ENABLE_LLM_CACHE = True
     #   AI_EXTENSIONS_LLM_CACHE = {
-    #       "enabled": True,
     #       "type": "redis",
     #       "host": "localhost",
     #       "port": 6379,
     #   }
+    if not hasattr(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE"):
+        settings.AI_EXTENSIONS_ENABLE_LLM_CACHE = False
     if not hasattr(settings, "AI_EXTENSIONS_LLM_CACHE"):
-        settings.AI_EXTENSIONS_LLM_CACHE = {"enabled": False}
+        settings.AI_EXTENSIONS_LLM_CACHE = {}
 
     # -------------------------
     # Default field filters

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from openedx_ai_extensions.functions.decorators import TOOLS_SCHEMA
+from openedx_ai_extensions.models import PromptTemplate
 from openedx_ai_extensions.processors.llm.litellm_base_processor import LitellmProcessor
 
 User = get_user_model()
@@ -737,7 +738,7 @@ def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint
 })
 @patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: "not-a-dict")
 @pytest.mark.django_db
-def test_caching_disabled_when_cache_settings_invalid_type(_, __):  # pylint: disable=unused-argument
+def test_caching_disabled_when_cache_settings_invalid_type(_, __):
     """
     Test that when AI_EXTENSIONS_LLM_CACHE is not a dict an error is logged,
     caching is disabled, and the missing-setting warning is also emitted because
@@ -786,3 +787,159 @@ def test_caching_disabled_when_cache_setting_absent(mock_settings):  # pylint: d
         mock_logger.warning.assert_called_once_with(
             "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
         )
+
+
+# ============================================================================
+# Prompt Loading Tests
+# ============================================================================
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_load_prompt_from_template(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that _load_prompt returns the prompt text from a PromptTemplate
+    when prompt_template is set in config and the template exists.
+    """
+    config = {
+        "LitellmProcessor": {
+            "prompt_template": "my-template-slug",
+        }
+    }
+    with patch.object(PromptTemplate, "load_prompt", return_value="You are a helpful assistant.") as mock_load:
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        mock_load.assert_called_once_with("my-template-slug")
+        assert processor.custom_prompt == "You are a helpful assistant."
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_load_prompt_falls_back_to_inline_when_template_missing(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that _load_prompt falls back to the inline 'prompt' config value when
+    prompt_template is set but PromptTemplate.load_prompt returns None
+    (e.g. template slug not found in the DB).
+    """
+    config = {
+        "LitellmProcessor": {
+            "prompt_template": "nonexistent-slug",
+            "prompt": "Fallback inline prompt.",
+        }
+    }
+    with patch.object(PromptTemplate, "load_prompt", return_value=None):
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        assert processor.custom_prompt == "Fallback inline prompt."
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_load_prompt_inline_only(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that _load_prompt uses the inline 'prompt' value when no prompt_template
+    is configured.
+    """
+    config = {
+        "LitellmProcessor": {
+            "prompt": "Direct inline prompt.",
+        }
+    }
+    processor = LitellmProcessor(config=config, user_session=None)
+
+    assert processor.custom_prompt == "Direct inline prompt."
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_load_prompt_returns_none_when_not_configured(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that _load_prompt returns None when neither prompt_template nor prompt
+    is present in config.
+    """
+    config = {
+        "LitellmProcessor": {}
+    }
+    processor = LitellmProcessor(config=config, user_session=None)
+
+    assert processor.custom_prompt is None
+
+
+# ============================================================================
+# Options Override Tests
+# ============================================================================
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+        "TEMPERATURE": 0.7,
+        "MAX_TOKENS": 1000,
+    }
+})
+@pytest.mark.django_db
+def test_options_override_provider_settings(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that values in the 'options' config dict take precedence over provider
+    settings from AI_EXTENSIONS, and that extra constructor extra_params take
+    precedence over both.
+    """
+    config = {
+        "LitellmProcessor": {
+            "options": {
+                "TEMPERATURE": 0.2,
+                "MAX_TOKENS": 500,
+            }
+        }
+    }
+    processor = LitellmProcessor(config=config, user_session=None)
+
+    # options values override the provider defaults
+    assert processor.extra_params["temperature"] == 0.2
+    assert processor.extra_params["max_tokens"] == 500
+    # model is still inherited from the provider
+    assert processor.extra_params["model"] == "openai/gpt-4"
+
+
+# ============================================================================
+# Enabled Tools Wildcard Tests
+# ============================================================================
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_enabled_tools_all_wildcard_includes_every_tool(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that using '__all__' in enabled_tools enables every tool in TOOLS_SCHEMA.
+    """
+    config = {
+        "LitellmProcessor": {
+            "enabled_tools": ["__all__"],
+        }
+    }
+    processor = LitellmProcessor(config=config, user_session=None)
+
+    assert "tools" in processor.extra_params
+    assert len(processor.extra_params["tools"]) == len(TOOLS_SCHEMA)
+    for schema in TOOLS_SCHEMA.values():
+        assert schema in processor.extra_params["tools"]

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -759,3 +759,30 @@ def test_caching_disabled_when_cache_settings_invalid_type(_, __):  # pylint: di
         assert warning_calls[1][0][0] == (
             "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
         )
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_caching_disabled_when_cache_setting_absent(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that when AI_EXTENSIONS_LLM_CACHE is not defined on settings at all,
+    cache=True in config still results in caching being disabled and a warning
+    logged. The getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {}) fallback returns
+    {} so enabled is never True.
+    """
+    config = {
+        "LitellmProcessor": {
+            "cache": True,
+        }
+    }
+    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        assert processor.caching_enabled is False
+        mock_logger.warning.assert_called_once_with(
+            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
+        )

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -665,7 +665,7 @@ def test_mcp_configs_multiple_servers(mock_mcp_configs, mock_settings):  # pylin
 @patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @patch.object(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", new=True)
 @pytest.mark.django_db
-def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  # pylint: disable=unused-argument
+def test_caching_enabled_when_configured():
     """
     Test that caching is enabled when cache=True in config and
     AI_EXTENSIONS_ENABLE_LLM_CACHE is True.
@@ -683,7 +683,7 @@ def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  #
 @patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @patch.object(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", new=False)
 @pytest.mark.django_db
-def test_caching_disabled_when_cache_settings_disabled(_, __):
+def test_caching_disabled_when_cache_settings_disabled():
     """
     Test that caching is disabled when cache=True in config but
     AI_EXTENSIONS_ENABLE_LLM_CACHE is False, and a warning is logged.
@@ -704,7 +704,7 @@ def test_caching_disabled_when_cache_settings_disabled(_, __):
 
 @patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @pytest.mark.django_db
-def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint: disable=unused-argument
+def test_caching_disabled_when_not_requested_in_config():
     """
     Test that caching is disabled and no warning is emitted when cache is not
     set in config, regardless of AI_EXTENSIONS_ENABLE_LLM_CACHE.
@@ -721,7 +721,7 @@ def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint
 
 @patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @pytest.mark.django_db
-def test_caching_disabled_when_cache_setting_absent(mock_settings):  # pylint: disable=unused-argument
+def test_caching_disabled_when_cache_setting_absent():
     """
     Test that when AI_EXTENSIONS_ENABLE_LLM_CACHE is not defined on settings
     at all, cache=True in config still results in caching being disabled and a

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -654,3 +654,30 @@ def test_mcp_configs_multiple_servers(mock_mcp_configs, mock_settings):  # pylin
     # Verify tools parameter was set
     assert "tools" in processor.extra_params
     assert len(processor.extra_params["tools"]) == 2
+
+
+# ============================================================================
+# Caching Configuration Tests
+# ============================================================================
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: {"enabled": True})
+@pytest.mark.django_db
+def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that caching is enabled when cache=True in config and AI_EXTENSIONS_LLM_CACHE
+    has enabled=True.
+    """
+    config = {
+        "LitellmProcessor": {
+            "cache": True,
+        }
+    }
+    processor = LitellmProcessor(config=config, user_session=None)
+
+    assert processor.caching_enabled is True

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -681,3 +681,29 @@ def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  #
     processor = LitellmProcessor(config=config, user_session=None)
 
     assert processor.caching_enabled is True
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: {"enabled": False})
+@pytest.mark.django_db
+def test_caching_disabled_when_cache_settings_disabled(_, __):
+    """
+    Test that caching is disabled when cache=True in config but AI_EXTENSIONS_LLM_CACHE
+    has enabled=False, and a warning is logged.
+    """
+    config = {
+        "LitellmProcessor": {
+            "cache": True,
+        }
+    }
+    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        assert processor.caching_enabled is False
+        mock_logger.warning.assert_called_once_with(
+            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
+        )

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -707,3 +707,55 @@ def test_caching_disabled_when_cache_settings_disabled(_, __):
         mock_logger.warning.assert_called_once_with(
             "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
         )
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@pytest.mark.django_db
+def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint: disable=unused-argument
+    """
+    Test that caching is disabled and no warning is emitted when cache is not
+    set in config, regardless of AI_EXTENSIONS_LLM_CACHE.
+    """
+    config = {
+        "LitellmProcessor": {}
+    }
+    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        assert processor.caching_enabled is False
+        mock_logger.warning.assert_not_called()
+
+
+@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
+    "default": {
+        "MODEL": "openai/gpt-4",
+    }
+})
+@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: "not-a-dict")
+@pytest.mark.django_db
+def test_caching_disabled_when_cache_settings_invalid_type(_, __):  # pylint: disable=unused-argument
+    """
+    Test that when AI_EXTENSIONS_LLM_CACHE is not a dict an error is logged,
+    caching is disabled, and the missing-setting warning is also emitted because
+    cache=True was requested in config.
+    """
+    config = {
+        "LitellmProcessor": {
+            "cache": True,
+        }
+    }
+    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
+        processor = LitellmProcessor(config=config, user_session=None)
+
+        assert processor.caching_enabled is False
+        warning_calls = mock_logger.warning.call_args_list
+        # First warning: invalid type for AI_EXTENSIONS_LLM_CACHE
+        assert "AI_EXTENSIONS_LLM_CACHE setting must be a dict" in warning_calls[0][0][0]
+        # Second warning: cache requested but effectively disabled
+        assert warning_calls[1][0][0] == (
+            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
+        )

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -662,17 +662,13 @@ def test_mcp_configs_multiple_servers(mock_mcp_configs, mock_settings):  # pylin
 # ============================================================================
 
 
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
-@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: {"enabled": True})
+@patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
+@patch.object(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", new=True)
 @pytest.mark.django_db
 def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  # pylint: disable=unused-argument
     """
-    Test that caching is enabled when cache=True in config and AI_EXTENSIONS_LLM_CACHE
-    has enabled=True.
+    Test that caching is enabled when cache=True in config and
+    AI_EXTENSIONS_ENABLE_LLM_CACHE is True.
     """
     config = {
         "LitellmProcessor": {
@@ -684,17 +680,13 @@ def test_caching_enabled_when_configured(mock_cache_settings, mock_settings):  #
     assert processor.caching_enabled is True
 
 
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
-@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: {"enabled": False})
+@patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
+@patch.object(settings, "AI_EXTENSIONS_ENABLE_LLM_CACHE", new=False)
 @pytest.mark.django_db
 def test_caching_disabled_when_cache_settings_disabled(_, __):
     """
-    Test that caching is disabled when cache=True in config but AI_EXTENSIONS_LLM_CACHE
-    has enabled=False, and a warning is logged.
+    Test that caching is disabled when cache=True in config but
+    AI_EXTENSIONS_ENABLE_LLM_CACHE is False, and a warning is logged.
     """
     config = {
         "LitellmProcessor": {
@@ -706,20 +698,16 @@ def test_caching_disabled_when_cache_settings_disabled(_, __):
 
         assert processor.caching_enabled is False
         mock_logger.warning.assert_called_once_with(
-            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
+            "Caching is disabled in settings. Set AI_EXTENSIONS_ENABLE_LLM_CACHE = True to use caching."
         )
 
 
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
+@patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @pytest.mark.django_db
 def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint: disable=unused-argument
     """
     Test that caching is disabled and no warning is emitted when cache is not
-    set in config, regardless of AI_EXTENSIONS_LLM_CACHE.
+    set in config, regardless of AI_EXTENSIONS_ENABLE_LLM_CACHE.
     """
     config = {
         "LitellmProcessor": {}
@@ -731,49 +719,13 @@ def test_caching_disabled_when_not_requested_in_config(mock_settings):  # pylint
         mock_logger.warning.assert_not_called()
 
 
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
-@patch.object(settings, "AI_EXTENSIONS_LLM_CACHE", new_callable=lambda: "not-a-dict")
-@pytest.mark.django_db
-def test_caching_disabled_when_cache_settings_invalid_type(_, __):
-    """
-    Test that when AI_EXTENSIONS_LLM_CACHE is not a dict an error is logged,
-    caching is disabled, and the missing-setting warning is also emitted because
-    cache=True was requested in config.
-    """
-    config = {
-        "LitellmProcessor": {
-            "cache": True,
-        }
-    }
-    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
-        processor = LitellmProcessor(config=config, user_session=None)
-
-        assert processor.caching_enabled is False
-        warning_calls = mock_logger.warning.call_args_list
-        # First warning: invalid type for AI_EXTENSIONS_LLM_CACHE
-        assert "AI_EXTENSIONS_LLM_CACHE setting must be a dict" in warning_calls[0][0][0]
-        # Second warning: cache requested but effectively disabled
-        assert warning_calls[1][0][0] == (
-            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
-        )
-
-
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
+@patch.object(settings, "AI_EXTENSIONS", new={"default": {"MODEL": "openai/gpt-4"}})
 @pytest.mark.django_db
 def test_caching_disabled_when_cache_setting_absent(mock_settings):  # pylint: disable=unused-argument
     """
-    Test that when AI_EXTENSIONS_LLM_CACHE is not defined on settings at all,
-    cache=True in config still results in caching being disabled and a warning
-    logged. The getattr(settings, "AI_EXTENSIONS_LLM_CACHE", {}) fallback returns
-    {} so enabled is never True.
+    Test that when AI_EXTENSIONS_ENABLE_LLM_CACHE is not defined on settings
+    at all, cache=True in config still results in caching being disabled and a
+    warning logged (getattr fallback returns False).
     """
     config = {
         "LitellmProcessor": {
@@ -785,7 +737,7 @@ def test_caching_disabled_when_cache_setting_absent(mock_settings):  # pylint: d
 
         assert processor.caching_enabled is False
         mock_logger.warning.assert_called_once_with(
-            "Caching is disabled in settings. Please enable AI_EXTENSIONS_LLM_CACHE to use caching."
+            "Caching is disabled in settings. Set AI_EXTENSIONS_ENABLE_LLM_CACHE = True to use caching."
         )
 
 

--- a/docs/decisions/0004-llm-caching-strategy.rst
+++ b/docs/decisions/0004-llm-caching-strategy.rst
@@ -1,0 +1,99 @@
+0004 LLM Caching Strategy
+#########################
+
+Status
+******
+**Proposed**
+
+Context
+*******
+
+As the number of AI-powered workflows in the platform grows, so does the volume and
+cost of LLM API calls. Repeated or structurally similar requests — such as summarizing
+the same content, generating questions for a shared lesson, or running system-prompted
+workflows — represent an opportunity for caching to reduce both latency and API spend.
+
+Two distinct caching mechanisms are available through LiteLLM, and they operate at
+different layers:
+
+1. **LiteLLM Proxy Response Caching** — LiteLLM intercepts requests and returns a
+   previously stored full response when an identical request is detected (same model,
+   messages, temperature, etc.). This is a client-side cache from the LLM provider's
+   perspective. Supported backends include: in-memory, disk, Redis, S3, GCS, and
+   semantic (Qdrant/Redis). Cache behaviour can be controlled per-request using
+   ``ttl``, ``s-maxage``, ``no-cache``, ``no-store``, and ``namespace`` parameters.
+
+   **Critical limitation**: This mechanism does **not** support the OpenAI ``/responses``
+   API endpoint (``responses`` call type). It only works for ``/chat/completions``,
+   ``/completions``, ``/embeddings``, and ``/audio/transcriptions``. Any workflow that
+   relies on the Responses API cannot benefit from this cache layer.
+
+2. **Provider-Side Prompt Caching** — The LLM provider (OpenAI, Anthropic, Bedrock,
+   Deepseek) caches the KV-tensor computation for the prompt prefix. The API is still
+   called, but token processing cost and latency are reduced for cache hits. LiteLLM
+   transparently surfaces cache usage through a normalised ``prompt_tokens_details.cached_tokens``
+   field in the response.
+
+   Provider behaviour differs:
+
+   * **OpenAI**: Automatic for any prompt with 1,024+ tokens. No code changes needed.
+     Optional ``prompt_cache_key`` and ``prompt_cache_retention`` parameters allow
+     routing hints and TTL control (``"in_memory"`` ≈ 5–10 min vs ``"24h"``).
+   * **Anthropic**: Opt-in. Specific message blocks must be annotated with
+     ``"cache_control": {"type": "ephemeral"}``. Anthropic charges for cache-write
+     tokens (``cache_creation_input_tokens``) in addition to normal input tokens, so
+     it is only cost-effective when the same annotated content is reused across multiple
+     requests.
+   * **Bedrock / Deepseek**: Follow the same pattern as OpenAI (automatic or opt-in
+     depending on the model).
+
+   LiteLLM can automatically inject ``cache_control`` annotations via
+   ``cache_control_injection_points`` without requiring application code changes.
+
+The combination of these two mechanisms must be evaluated against the call types
+actually used in the platform. Currently several workflows rely on the OpenAI
+Responses API, which makes LiteLLM proxy caching unavailable for those paths.
+
+Decision
+********
+
+No single caching strategy is adopted globally. Instead, the following approach is
+proposed as a baseline to be refined as usage patterns become clearer:
+
+* **Proxy response caching** (Redis-backed) is enabled **only** for call types that
+  are compatible with it (``acompletion``, ``atext_completion``, ``aembedding``).
+  The ``supported_call_types`` setting in ``cache_params`` must explicitly exclude
+  ``responses`` until LiteLLM adds support for that endpoint.
+
+* **Prompt caching** is enabled where possible at the provider level:
+
+  * For OpenAI-backed workflows, no code change is needed beyond ensuring system
+    prompts exceed 1,024 tokens or structuring requests so the cacheable prefix is
+    long enough.
+  * For Anthropic-backed workflows, ``cache_control`` annotations are added to
+    large, stable system-prompt blocks. Cost implications (write charges) must be
+    assessed per workflow before enabling.
+  * LiteLLM's ``cache_control_injection_points`` feature is preferred over manual
+    annotation when the system message is the primary caching target.
+
+* Cache TTL defaults to **600 seconds** for proxy caching. Workflows with
+  highly dynamic outputs (e.g., chat with real-time context) should set ``no-store``
+  on individual requests.
+
+* Cache hits and ``cached_tokens`` values are monitored via LiteLLM's
+  ``/cache/ping`` health endpoint and usage objects to validate cost savings.
+
+Consequences
+************
+
+* Workflows using ``/chat/completions`` and ``/embeddings`` benefit from full
+  response deduplication via Redis, reducing redundant API calls for repeated
+  identical requests.
+* Workflows using the OpenAI Responses API receive **no** proxy-level caching
+  benefit until LiteLLM adds ``responses`` to its supported cache call types.
+* Provider-side prompt caching provides latency and cost reductions for large,
+  stable system prompts regardless of call type, including the Responses API.
+* Enabling Anthropic prompt caching without usage analysis may **increase** costs
+  due to cache-write token charges; this must be verified per workflow.
+* Introducing Redis as a cache backend adds an infrastructure dependency that
+  operators must provision and maintain.

--- a/docs/decisions/0004-llm-caching-strategy.rst
+++ b/docs/decisions/0004-llm-caching-strategy.rst
@@ -3,7 +3,7 @@
 
 Status
 ******
-**Proposed**
+**Provisional**
 
 Context
 *******

--- a/tutor/openedx_ai_extensions/patches/openedx-common-settings
+++ b/tutor/openedx_ai_extensions/patches/openedx-common-settings
@@ -5,3 +5,10 @@ AI_EXTENSIONS_MCP_CONFIGS = {
   {%- endfor %}
 }
 {%- endif %}
+
+AI_EXTENSIONS_LLM_CACHE = {
+    "enabled": True,
+    "type": "redis",
+    "host": "{{ REDIS_HOST }}",
+    "port": {{ REDIS_PORT }},
+}

--- a/tutor/openedx_ai_extensions/patches/openedx-common-settings
+++ b/tutor/openedx_ai_extensions/patches/openedx-common-settings
@@ -6,9 +6,15 @@ AI_EXTENSIONS_MCP_CONFIGS = {
 }
 {%- endif %}
 
+{%- if AI_EXTENSIONS_LLM_CACHE_ENABLED is defined and AI_EXTENSIONS_LLM_CACHE_ENABLED %}
 AI_EXTENSIONS_LLM_CACHE = {
     "enabled": True,
     "type": "redis",
     "host": "{{ REDIS_HOST }}",
     "port": {{ REDIS_PORT }},
 }
+{%- else %}
+AI_EXTENSIONS_LLM_CACHE = {
+    "enabled": False,
+}
+{%- endif %}

--- a/tutor/openedx_ai_extensions/patches/openedx-common-settings
+++ b/tutor/openedx_ai_extensions/patches/openedx-common-settings
@@ -6,13 +6,12 @@ AI_EXTENSIONS_MCP_CONFIGS = {
 }
 {%- endif %}
 
-{%- set llm_cache = AI_EXTENSIONS_LLM_CACHE if AI_EXTENSIONS_LLM_CACHE is defined else {"enabled": false} %}
-{%- set llm_cache_enabled = llm_cache.get("enabled", false) %}
+AI_EXTENSIONS_ENABLE_LLM_CACHE = {{ "True" if AI_EXTENSIONS_ENABLE_LLM_CACHE else "False" }}
+{%- if AI_EXTENSIONS_ENABLE_LLM_CACHE %}
+{%- set llm_cache = AI_EXTENSIONS_LLM_CACHE if AI_EXTENSIONS_LLM_CACHE is defined else {} %}
 AI_EXTENSIONS_LLM_CACHE = {
-    "enabled": {{ "True" if llm_cache_enabled else "False" }},
-    {%- if llm_cache_enabled %}
     "type": {{ llm_cache.get("type", "redis") | tojson }},
     "host": {{ llm_cache.get("host", REDIS_HOST) | tojson }},
     "port": {{ llm_cache.get("port", REDIS_PORT) }},
-    {%- endif %}
 }
+{%- endif %}

--- a/tutor/openedx_ai_extensions/patches/openedx-common-settings
+++ b/tutor/openedx_ai_extensions/patches/openedx-common-settings
@@ -6,15 +6,13 @@ AI_EXTENSIONS_MCP_CONFIGS = {
 }
 {%- endif %}
 
-{%- if AI_EXTENSIONS_LLM_CACHE_ENABLED is defined and AI_EXTENSIONS_LLM_CACHE_ENABLED %}
+{%- set llm_cache = AI_EXTENSIONS_LLM_CACHE if AI_EXTENSIONS_LLM_CACHE is defined else {"enabled": false} %}
+{%- set llm_cache_enabled = llm_cache.get("enabled", false) %}
 AI_EXTENSIONS_LLM_CACHE = {
-    "enabled": True,
-    "type": "redis",
-    "host": "{{ REDIS_HOST }}",
-    "port": {{ REDIS_PORT }},
+    "enabled": {{ "True" if llm_cache_enabled else "False" }},
+    {%- if llm_cache_enabled %}
+    "type": {{ llm_cache.get("type", "redis") | tojson }},
+    "host": {{ llm_cache.get("host", REDIS_HOST) | tojson }},
+    "port": {{ llm_cache.get("port", REDIS_PORT) }},
+    {%- endif %}
 }
-{%- else %}
-AI_EXTENSIONS_LLM_CACHE = {
-    "enabled": False,
-}
-{%- endif %}

--- a/tutor/openedx_ai_extensions/patches/openedx-common-settings
+++ b/tutor/openedx_ai_extensions/patches/openedx-common-settings
@@ -13,5 +13,6 @@ AI_EXTENSIONS_LLM_CACHE = {
     "type": {{ llm_cache.get("type", "redis") | tojson }},
     "host": {{ llm_cache.get("host", REDIS_HOST) | tojson }},
     "port": {{ llm_cache.get("port", REDIS_PORT) }},
+    "ttl": {{ llm_cache.get("ttl", 259200) }},  # 72 hours
 }
 {%- endif %}

--- a/tutor/openedx_ai_extensions/plugin.py
+++ b/tutor/openedx_ai_extensions/plugin.py
@@ -44,7 +44,8 @@ def _mount_plugin(mounts, path):
 ########################
 
 hooks.Filters.CONFIG_DEFAULTS.add_items([
-    ("AI_EXTENSIONS_LLM_CACHE", {"enabled": False}),
+    ("AI_EXTENSIONS_ENABLE_LLM_CACHE", False),
+    ("AI_EXTENSIONS_LLM_CACHE", {}),
 ])
 
 # Actually connects the patch files as tutor env patches

--- a/tutor/openedx_ai_extensions/plugin.py
+++ b/tutor/openedx_ai_extensions/plugin.py
@@ -39,6 +39,14 @@ def _mount_plugin(mounts, path):
     mounts += [("openedx-ai-extensions-backend", "/openedx/openedx-ai-extensions/backend")]
     return mounts
 
+########################
+# Configuration defaults
+########################
+
+hooks.Filters.CONFIG_DEFAULTS.add_items([
+    ("AI_EXTENSIONS_LLM_CACHE", {"enabled": False}),
+])
+
 # Actually connects the patch files as tutor env patches
 for path in glob(str(importlib_resources.files("openedx_ai_extensions") / "patches" / "*")):
     with open(path, encoding="utf-8") as patch_file:


### PR DESCRIPTION
This PR add client-side caché implementation using Litellm tools.

Same prompts + models are stored in defined caché and Litellm take it before hitting the api.

NOTE: Cache functionality is not allowed for responses api.

## Test instructions

1. Add

``` yaml
 AI_EXTENSIONS_LLM_CACHE:
  enabled: true

```
 to config.yaml and do `tutor config save` to load REDIS data to Litellm through Tutor.
4. Allow caché in any profile which uses `completion` api:

Content-patch: 
``` json
{
  "processor_config": {
    "LLMProcessor": {
      ....
      "cache": true,
    }
  }
}
```
5. Setup an scope with that profile and use it with two different users, the second user should have the answer quickly and both should have the same answer
6. Test the responses aren't the same when `cache: false`