### PR TITLE
refactor: make course_id and location_id optional in get_profile

### DIFF
--- a/backend/openedx_ai_extensions/workflows/models.py
+++ b/backend/openedx_ai_extensions/workflows/models.py
@@ -222,7 +222,7 @@ class AIWorkflowScope(models.Model):
 
     @classmethod
     @functools.lru_cache(maxsize=128)
-    def get_profile(cls, course_id, location_id):
+    def get_profile(cls, course_id=None, location_id=None):
         """
         Get configuration for a specific action, course, and location and service variant.
 


### PR DESCRIPTION
## Description

Make course_id and location_id optional in get_profile.

Reasoning:
In the function we are asking `if location_id`, and for the course_id check we have a try-except, so we can obtain the profile withouth the `course_id` and `location_id`, so I made them optional.

## More details

I am adding this to be able to make workflow calls without a location.
Specific use: https://github.com/eduNEXT/openedx-ai-badges/pull/8