### PR TITLE
refactor: llmprocessor accepts extra_params for direct litellm config

### DIFF
--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -16,10 +16,27 @@ logger = logging.getLogger(__name__)
 
 
 class LLMProcessor(LitellmProcessor):
-    """Handles AI processing using LiteLLM with support for threaded conversations."""
+    """
+    Handles AI processing using LiteLLM with support for threaded conversations.
 
-    def __init__(self, config=None, user_session=None, **kwargs):
-        super().__init__(config, user_session, **kwargs)
+    This processor accepts an optional extra_params argument in its constructor,
+    which is passed directly to the LitellmProcessor base class. This allows you to
+    configure advanced LiteLLM parameters such as:
+
+        - model: str (e.g., 'openai/gpt-4')
+        - temperature: float (e.g., 0.7)
+        - max_tokens: int (e.g., 150)
+        - api_key: str
+        - response_format: dict
+        - and any other parameters supported by the underlying LiteLLM client
+    """
+
+    def __init__(self, config=None, user_session=None, extra_params=None):
+        """
+        Initialize LLMProcessor. extra_params is passed to LitellmProcessor for
+        advanced configuration.
+        """
+        super().__init__(config, user_session, extra_params)
         self.chat_history = None
         self.input_data = None
         self.context = None

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -18,8 +18,8 @@ logger = logging.getLogger(__name__)
 class LLMProcessor(LitellmProcessor):
     """Handles AI processing using LiteLLM with support for threaded conversations."""
 
-    def __init__(self, config=None, user_session=None):
-        super().__init__(config, user_session)
+    def __init__(self, config=None, user_session=None, **kwargs):
+        super().__init__(config, user_session, **kwargs)
         self.chat_history = None
         self.input_data = None
         self.context = None

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -2,7 +2,7 @@
 Tests for the LLMProcessor module.
 """
 # pylint: disable=redefined-outer-name,protected-access
-
+import unittest
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1017,3 +1017,26 @@ class TestExtractOutputItems:
 
         result = LLMProcessor._extract_output_items(resp)
         assert not result
+
+
+# --- LLMProcessor __init__ kwargs pass-through test ---
+class TestLLMProcessorInit(unittest.TestCase):
+    """
+    Test that LLMProcessor.__init__ correctly passes kwargs to LitellmProcessor.__init__.
+    """
+    @patch('openedx_ai_extensions.processors.llm.llm_processor.LitellmProcessor.__init__', return_value=None)
+    def test_llmprocessor_init_passes_kwargs(self, mock_litellm_init):
+        """
+        Test that LLMProcessor.__init__ passes all kwargs to LitellmProcessor.__init__.
+        """
+        config = {'foo': 'bar'}
+        user_session = object()
+        extra_params = {
+            'temperature': 0.7,
+            'model': 'gpt-4',
+            'max_tokens': 150,
+            'api_key': 'test-key',
+            'response_format': {'type': 'json'}
+        }
+        processor = LLMProcessor(config, user_session, extra_params=extra_params)    # pylint: disable=unused-variable
+        mock_litellm_init.assert_called_once_with(config, user_session, extra_params)


### PR DESCRIPTION
## Description

This PR is inspired by the changes in #155 that allows to pass more info to the litellm.

The goal of this change is to enable passing more arguments through the LLMProcessor instead of setting them manually.

Specific use case: passing extra_params to set a response_format.

## Before and after
Before
```python
class BaseBadgeLLMProcessor(LLMProcessor):
    def __init__(self, config=None, user_session=None):
        super().__init__(config, user_session)
        schema_path = (
            Path(__file__).resolve().parent
            / "response_schemas"
            / "openbadge-3.0-achievement.json"
        )
        # Manual setting
        with open(schema_path, 'r', encoding='utf-8') as f:
            self.extra_params['response_format'] = json.load(f)
```
After
```python
class BaseBadgeLLMProcessor(LLMProcessor):
    def __init__(self, config=None, user_session=None):
        schema_path = (
            Path(__file__).resolve().parent
            / "response_schemas"
            / "openbadge-3.0-achievement.json"
        )
        with open(schema_path, 'r', encoding='utf-8') as f:
            extra_params = {'response_format': json.load(f)}

        # It is handled by the LLMProcessor
        super().__init__(config, user_session, extra_params=extra_params)
```

## How to test
I'm using this change in this PR: https://github.com/eduNEXT/openedx-ai-badges/pull/9

## Note

At the beginning, I thought of using this change to refactor. It doesn't reduce the code much, but it handles the params inside the base class, so it is easier to maintain.