### PR TITLE
feat: enable functions in streaming

### DIFF
--- a/backend/openedx_ai_extensions/functions/external_function_example.py
+++ b/backend/openedx_ai_extensions/functions/external_function_example.py
@@ -35,4 +35,5 @@ logger = logging.getLogger(__name__)
 def roll_dice(n_dice=1, **kwargs):
     """Simulate rolling a specified number of six-sided dice."""
     roll = [random.randint(1, 6) for _ in range(n_dice)]
+    logger.info(f"Rolling dice using functions. Rolled {roll}")
     return roll

--- a/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/litellm_base_processor.py
@@ -61,10 +61,6 @@ class LitellmProcessor:
             if functions_schema_filtered:
                 self.extra_params["tools"] = functions_schema_filtered
 
-        if self.stream and "tools" in self.extra_params:
-            logger.warning("Streaming responses with tools is not supported; disabling streaming.")
-            self.stream = False
-
         self.mcp_configs = {}
         allowed_mcp_configs = self.config.get("mcp_configs", [])
         if allowed_mcp_configs:

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -263,12 +263,26 @@ class LLMProcessor(LitellmProcessor):
         """Handle tool calls recursively until no more tool calls are present."""
         for tool_call in tool_calls:
             function_name = tool_call.function.name
-            function_to_call = AVAILABLE_TOOLS[function_name]
-            function_args = json.loads(tool_call.function.arguments)
 
-            function_response = function_to_call(
-                **function_args,
-            )
+            # Ensure tool exists
+            if function_name not in AVAILABLE_TOOLS:
+                logger.error(f"Tool '{function_name}' requested by LLM but not available locally.")
+                continue
+
+            function_to_call = AVAILABLE_TOOLS[function_name]
+            logger.info(f"[LLM] Tool call: {function_to_call}")
+
+            try:
+                function_args = json.loads(tool_call.function.arguments)
+                function_response = function_to_call(**function_args)
+                logger.info(f"[LLM] Response from tool call: {function_response}")
+            except json.JSONDecodeError:
+                function_response = "Error: Invalid JSON arguments provided."
+                logger.error(f"Failed to parse JSON arguments for {function_name}")
+            except Exception as e:  # pylint: disable=broad-exception-caught
+                function_response = f"Error executing tool: {str(e)}"
+                logger.error(f"Error executing tool {function_name}: {e}")
+
             params["messages"].append(
                 {
                     "tool_call_id": tool_call.id,
@@ -281,10 +295,9 @@ class LLMProcessor(LitellmProcessor):
         # Call completion again with updated messages
         response = completion(**params)
 
-        # For streaming, return the generator immediately
-        # Tool calls are not supported in streaming mode
+        # For streaming, we need to handle the stream to detect tool calls
         if params.get("stream"):
-            return response
+            return self._handle_streaming_tool_calls(response, params)
 
         # For non-streaming, check for tool calls and handle recursively
         new_tool_calls = response.choices[0].message.tool_calls
@@ -293,6 +306,99 @@ class LLMProcessor(LitellmProcessor):
             return self._completion_with_tools(new_tool_calls, params)
 
         return response
+
+    def _handle_streaming_tool_calls(self, response, params):
+        """
+        Generator that handles streaming responses containing tool calls.
+        It accumulates tool call chunks, executes them, and recursively calls completion.
+        """
+        tool_calls_buffer = {}  # index -> {id, function: {name, arguments}}
+        accumulating_tools = False
+        logger.info("[LLM STREAM] Streaming tool calls")
+
+        for chunk in response:
+            delta = chunk.choices[0].delta
+
+            # If there is content, yield it immediately to the user
+            if delta.content:
+                yield chunk
+
+            # If there are tool calls, buffer them
+            if delta.tool_calls:
+                if not accumulating_tools:
+                    logger.info("[AI STREAM] Start: buffer function")
+                accumulating_tools = True
+                for tc_chunk in delta.tool_calls:
+                    idx = tc_chunk.index
+
+                    if idx not in tool_calls_buffer:
+                        tool_calls_buffer[idx] = {
+                            "id": "",
+                            "type": "function",
+                            "function": {"name": "", "arguments": ""}
+                        }
+
+                    if tc_chunk.id:
+                        tool_calls_buffer[idx]["id"] += tc_chunk.id
+
+                    if tc_chunk.function:
+                        if tc_chunk.function.name:
+                            tool_calls_buffer[idx]["function"]["name"] += tc_chunk.function.name
+                        if tc_chunk.function.arguments:
+                            tool_calls_buffer[idx]["function"]["arguments"] += tc_chunk.function.arguments
+
+        # If we accumulated tool calls, reconstruct them and recurse
+        if accumulating_tools and tool_calls_buffer:
+
+            # Helper classes to mimic the object structure LiteLLM expects in _completion_with_tools
+            class FunctionMock:
+                def __init__(self, name, arguments):
+                    self.name = name
+                    self.arguments = arguments
+
+            class ToolCallMock:
+                def __init__(self, t_id, name, arguments):
+                    self.id = t_id
+                    self.function = FunctionMock(name, arguments)
+                    self.type = "function"
+
+            # Prepare list for the recursive call
+            reconstructed_tool_calls = []
+
+            # Prepare message to append to history (as dict for JSON serialization)
+            assistant_message_tool_calls = []
+
+            for idx in sorted(tool_calls_buffer.keys()):
+                data = tool_calls_buffer[idx]
+
+                # Create object for internal logic
+                tc_obj = ToolCallMock(
+                    t_id=data['id'],
+                    name=data['function']['name'],
+                    arguments=data['function']['arguments']
+                )
+                reconstructed_tool_calls.append(tc_obj)
+
+                # Create dict for history
+                assistant_message_tool_calls.append({
+                    "id": data['id'],
+                    "type": "function",
+                    "function": {
+                        "name": data['function']['name'],
+                        "arguments": data['function']['arguments']
+                    }
+                })
+
+            # Append the Assistant's intent to call tools to the history
+            params["messages"].append({
+                "role": "assistant",
+                "content": None,
+                "tool_calls": assistant_message_tool_calls
+            })
+
+            # Recursively call completion with the reconstructed tools
+            # yield from delegates the generation of the next stream (result of tool) to this generator
+            yield from self._completion_with_tools(reconstructed_tool_calls, params)
 
     def _responses_with_tools(self, tool_calls, params):
         """Handle tool calls recursively until no more tool calls are present."""

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -145,33 +145,90 @@ class LLMProcessor(LitellmProcessor):
 
         return params
 
-    def _yield_threaded_stream(self, response):
+    def _yield_threaded_stream(self, response, params=None):
         """
         Helper generator to handle streaming logic for threaded responses.
+        Handles tool calls execution recursively during streaming.
         """
         total_tokens = None
-        try:
+        try:  # pylint: disable=R1702
             for chunk in response:
-                if hasattr(chunk, "usage") and chunk.usage:
+                # Track token usage from the response metadata
+                chunk_response = getattr(chunk, "response", None)
+                if chunk_response and hasattr(chunk_response, "usage") and chunk_response.usage:
+                    total_tokens = chunk_response.usage.total_tokens
+                elif hasattr(chunk, "usage") and chunk.usage:
                     total_tokens = chunk.usage.total_tokens
 
-                if getattr(chunk, "response", None):
-                    resp = getattr(chunk, "response", None)
-                    if resp is not None:
-                        response_id = getattr(resp, "id", None)
-                        self.user_session.remote_response_id = response_id
-                        self.user_session.save()
+                # Persist thread ID for ongoing conversation context
+                if chunk_response:
+                    if chunk_response is not None and self.user_session:
+                        response_id = getattr(chunk_response, "id", None)
+                        if response_id:
+                            self.user_session.remote_response_id = response_id
+                            self.user_session.save()
+
+                # Stream text deltas, filtering out empty JSON artifacts
                 if hasattr(chunk, "delta"):
-                    yield chunk.delta
+                    yield chunk.delta if chunk.delta != "{}" else ""
+
+                # Check for completed tool call requests
+                chunk_type = getattr(chunk, "type", None)
+                if chunk_type == "response.output_item.done":
+                    item = chunk.item
+                    if getattr(item, "type", None) == "function_call":
+                        logger.info(f"[LLM STREAM] Intercepted tool call: {item.name}")
+
+                        function_name = item.name
+                        call_id = item.call_id
+                        arguments_str = item.arguments
+
+                        # Add function call intent to history (required for API consistency)
+                        if params is not None:
+                            params["input"].append({
+                                "type": "function_call",
+                                "call_id": call_id,
+                                "name": function_name,
+                                "arguments": arguments_str
+                            })
+
+                        # Parse arguments and execute the local function
+                        try:
+                            function_args = json.loads(arguments_str)
+                        except json.JSONDecodeError:
+                            function_args = {}
+
+                        if function_name in AVAILABLE_TOOLS:
+                            func = AVAILABLE_TOOLS[function_name]
+                            try:
+                                tool_output = func(**function_args)
+                            except Exception as e:  # pylint: disable=broad-exception-caught
+                                tool_output = f"Error: {str(e)}"
+                        else:
+                            tool_output = "Error: Tool not found."
+
+                        if params is None:
+                            yield "\n[System Error: Missing params]".encode("utf-8")
+                            return
+
+                        # Add tool output to history and re-trigger LLM response
+                        params["input"].append({
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": str(tool_output)
+                        })
+
+                        # Recursively stream the new response interpreting the tool output
+                        new_response = responses(**params)
+                        yield from self._yield_threaded_stream(new_response, params)
+                        return
 
             if total_tokens is not None:
                 logger.info(f"[LLM STREAM] Tokens used: {total_tokens}")
-            else:
-                logger.info("[LLM STREAM] Tokens used: unknown (model did not report)")
 
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error during threaded AI streaming: {e}", exc_info=True)
-            yield f"\n[AI Error: {e}]"
+            logger.error(f"Error: {e}", exc_info=True)
+            yield f"\n[AI Error: {e}]".encode("utf-8")
 
     def _call_responses_wrapper(self, params, initialize=False):
         """
@@ -181,7 +238,7 @@ class LLMProcessor(LitellmProcessor):
             response = self._responses_with_tools(tool_calls=[], params=params)
 
             if params["stream"]:
-                return self._yield_threaded_stream(response)
+                return self._yield_threaded_stream(response, params=params)
 
             response_id = getattr(response, "id", None)
             content = self._extract_response_content(response=response)

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -12,6 +12,7 @@ from litellm import completion, get_responses, list_input_items, responses
 from openedx_ai_extensions.functions.decorators import AVAILABLE_TOOLS
 from openedx_ai_extensions.processors.llm.litellm_base_processor import LitellmProcessor
 from openedx_ai_extensions.processors.llm.providers import adapt_to_provider, after_tool_call_adaptations
+from openedx_ai_extensions.utils import normalize_input_to_text
 
 logger = logging.getLogger(__name__)
 
@@ -115,20 +116,6 @@ class LLMProcessor(LitellmProcessor):
                 tool_calls.append(item)
         return tool_calls
 
-    @staticmethod
-    def _normalize_input_to_text(input_data) -> str:
-        """
-        Coerce input_data to a plain string suitable for use as message content.
-        Handles: str, dict with 'text' key, other dicts (JSON-serialised), None.
-        """
-        if isinstance(input_data, str):
-            return input_data
-        if isinstance(input_data, dict):
-            return input_data.get("text") or ""
-        if input_data is None:
-            return ""
-        return str(input_data)
-
     def _build_response_api_params(self, system_role=None):
         """
         Build completion parameters for LiteLLM responses API.
@@ -137,7 +124,7 @@ class LLMProcessor(LitellmProcessor):
         params["stream"] = self.stream
 
         if self.chat_history:
-            user_text = self._normalize_input_to_text(self.input_data)
+            user_text = normalize_input_to_text(self.input_data)
             if user_text:
                 self.chat_history.append({"role": "user", "content": user_text})
             params["input"] = self.chat_history
@@ -157,7 +144,8 @@ class LLMProcessor(LitellmProcessor):
             params,
             has_user_input=has_user_input,
             user_session=self.user_session,
-            input_data=self.input_data
+            input_data=self.input_data,
+            use_completion_api=(self.provider != "openai" and self.stream),
         )
 
         return params
@@ -171,19 +159,6 @@ class LLMProcessor(LitellmProcessor):
         """
         yield from self._handle_streaming_tool_calls_responses(response, params or {})
 
-    # Params that belong only to the Responses API and are unknown to completion().
-    _RESPONSES_API_ONLY_PARAMS = frozenset({"input", "previous_response_id", "store", "truncation"})
-
-    def _responses_params_to_completion_params(self, params: dict) -> dict:
-        """
-        Convert Responses API params to Completion API params.
-        Renames 'input' → 'messages' and drops Responses-API-only keys.
-        """
-        completion_params = {k: v for k, v in params.items()
-                             if k not in self._RESPONSES_API_ONLY_PARAMS}
-        completion_params["messages"] = params.get("input", [])
-        return completion_params
-
     def _call_responses_wrapper(self, params, initialize=False):
         """
         Wrapper around LiteLLM responses() call.
@@ -191,12 +166,10 @@ class LLMProcessor(LitellmProcessor):
         try:
             if params["stream"]:
                 if self.provider != "openai":
-                    # LiteLLM's Responses API streaming translation never surfaces
-                    # tool-call events for non-native providers (the done-event
-                    # always has type "message"). Use the Completion API path so
-                    # _handle_streaming_tool_calls can detect and execute tools.
-                    completion_params = self._responses_params_to_completion_params(params)
-                    response = self._completion_with_tools([], completion_params)
+                    # params was already converted to Completion API format by
+                    # adapt_to_provider (use_completion_api=True), so call
+                    # completion() directly so tool-call events are visible.
+                    response = self._completion_with_tools([], params)
                     return self._handle_streaming_completion(response)
 
                 raw_response = responses(**params)

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -4,6 +4,7 @@ Responses processor for threaded AI conversations using LiteLLM
 
 import json
 import logging
+import types
 from datetime import datetime, timezone
 
 from litellm import completion, get_responses, list_input_items, responses
@@ -252,12 +253,10 @@ class LLMProcessor(LitellmProcessor):
                 continue
 
             function_to_call = AVAILABLE_TOOLS[function_name]
-            logger.info(f"[LLM] Tool call: {function_to_call}")
 
             try:
                 function_args = json.loads(tool_call.function.arguments)
                 function_response = function_to_call(**function_args)
-                logger.info(f"[LLM] Response from tool call: {function_response}")
             except json.JSONDecodeError:
                 function_response = "Error: Invalid JSON arguments provided."
                 logger.error(f"Failed to parse JSON arguments for {function_name}")
@@ -289,194 +288,179 @@ class LLMProcessor(LitellmProcessor):
 
         return response
 
+    # -------------------------------------------------------------------------
+    # Shared tool-execution helpers
+    # -------------------------------------------------------------------------
+
+    def _execute_tool(self, function_name: str, arguments_str: str) -> str:
+        """
+        Parse *arguments_str* as JSON, look up *function_name* in AVAILABLE_TOOLS,
+        call it, and return the result as a string.
+        Returns a descriptive error string on any failure so the caller can
+        forward it to the LLM without raising.
+        """
+        if function_name not in AVAILABLE_TOOLS:
+            logger.error("Tool '%s' not found in AVAILABLE_TOOLS.", function_name)
+            return "Error: Tool not found."
+        try:
+            function_args = json.loads(arguments_str)
+        except json.JSONDecodeError:
+            logger.error("Failed to parse JSON arguments for '%s'.", function_name)
+            return "Error: Invalid JSON arguments provided."
+        try:
+            result = AVAILABLE_TOOLS[function_name](**function_args)
+            return str(result)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return f"Error executing tool: {e}"
+
+    # -------------------------------------------------------------------------
+    # Completion API streaming helpers
+    # -------------------------------------------------------------------------
+
+    @staticmethod
+    def _accumulate_tool_call_chunk(buffer: dict, tc_chunk) -> None:
+        """Merge a single streaming tool-call delta into the accumulation buffer."""
+        idx = tc_chunk.index
+        if idx not in buffer:
+            buffer[idx] = {"id": "", "type": "function", "function": {"name": "", "arguments": ""}}
+        if tc_chunk.id:
+            buffer[idx]["id"] += tc_chunk.id
+        if tc_chunk.function:
+            buffer[idx]["function"]["name"] += tc_chunk.function.name or ""
+            buffer[idx]["function"]["arguments"] += tc_chunk.function.arguments or ""
+
+    @staticmethod
+    def _reconstruct_tool_calls(buffer: dict):
+        """
+        Convert the chunk accumulation buffer into:
+        - a list of SimpleNamespace objects accepted by _completion_with_tools
+        - a list of dicts for the assistant history message
+        """
+        tool_call_objects = []
+        assistant_tool_calls = []
+        for idx in sorted(buffer):
+            data = buffer[idx]
+            fn = data["function"]
+            tool_call_objects.append(
+                types.SimpleNamespace(
+                    id=data["id"],
+                    type="function",
+                    function=types.SimpleNamespace(name=fn["name"], arguments=fn["arguments"]),
+                )
+            )
+            assistant_tool_calls.append({
+                "id": data["id"],
+                "type": "function",
+                "function": {"name": fn["name"], "arguments": fn["arguments"]},
+            })
+        return tool_call_objects, assistant_tool_calls
+
     def _handle_streaming_tool_calls(self, response, params):
         """
-        Generator that handles streaming responses containing tool calls.
-        It accumulates tool call chunks, executes them, and recursively calls completion.
+        Generator for Completion API streaming responses that may contain tool calls.
+        Yields content chunks immediately; accumulates tool-call deltas and replays
+        them after the stream ends via _completion_with_tools.
         """
-        tool_calls_buffer = {}  # index -> {id, function: {name, arguments}}
-        accumulating_tools = False
-        logger.info("[LLM STREAM] Streaming tool calls")
+        tool_calls_buffer = {}
 
         for chunk in response:
             delta = chunk.choices[0].delta
-
-            # If there is content, yield it immediately to the user
             if delta.content:
                 yield chunk
+            for tc_chunk in (delta.tool_calls or []):
+                self._accumulate_tool_call_chunk(tool_calls_buffer, tc_chunk)
 
-            # If there are tool calls, buffer them
-            if delta.tool_calls:
-                if not accumulating_tools:
-                    logger.info("[AI STREAM] Start: buffer function")
-                accumulating_tools = True
-                for tc_chunk in delta.tool_calls:
-                    idx = tc_chunk.index
+        if not tool_calls_buffer:
+            return
 
-                    if idx not in tool_calls_buffer:
-                        tool_calls_buffer[idx] = {
-                            "id": "",
-                            "type": "function",
-                            "function": {"name": "", "arguments": ""}
-                        }
+        tool_call_objects, assistant_tool_calls = self._reconstruct_tool_calls(tool_calls_buffer)
+        params["messages"].append({
+            "role": "assistant",
+            "content": None,
+            "tool_calls": assistant_tool_calls,
+        })
+        yield from self._completion_with_tools(tool_call_objects, params)
 
-                    if tc_chunk.id:
-                        tool_calls_buffer[idx]["id"] += tc_chunk.id
+    # -------------------------------------------------------------------------
+    # Responses API streaming helpers
+    # -------------------------------------------------------------------------
 
-                    if tc_chunk.function:
-                        if tc_chunk.function.name:
-                            tool_calls_buffer[idx]["function"]["name"] += tc_chunk.function.name
-                        if tc_chunk.function.arguments:
-                            tool_calls_buffer[idx]["function"]["arguments"] += tc_chunk.function.arguments
+    @staticmethod
+    def _get_chunk_token_usage(chunk) -> "int | None":
+        """Extract total token count from a Responses API streaming chunk, if present."""
+        chunk_response = getattr(chunk, "response", None)
+        if chunk_response and getattr(chunk_response, "usage", None):
+            return chunk_response.usage.total_tokens
+        if getattr(chunk, "usage", None):
+            return chunk.usage.total_tokens
+        return None
 
-        # If we accumulated tool calls, reconstruct them and recurse
-        if accumulating_tools and tool_calls_buffer:
+    def _persist_response_id(self, chunk) -> None:
+        """Save the response ID carried by *chunk* to the user session, if present."""
+        if not self.user_session:
+            return
+        chunk_response = getattr(chunk, "response", None)
+        response_id = chunk_response and getattr(chunk_response, "id", None)
+        if response_id:
+            self.user_session.remote_response_id = response_id
+            self.user_session.save()
 
-            # Helper classes to mimic the object structure LiteLLM expects in _completion_with_tools
-            class FunctionMock:
-                def __init__(self, name, arguments):
-                    self.name = name
-                    self.arguments = arguments
-
-            class ToolCallMock:
-                def __init__(self, t_id, name, arguments):
-                    self.id = t_id
-                    self.function = FunctionMock(name, arguments)
-                    self.type = "function"
-
-            # Prepare list for the recursive call
-            reconstructed_tool_calls = []
-
-            # Prepare message to append to history (as dict for JSON serialization)
-            assistant_message_tool_calls = []
-
-            for idx in sorted(tool_calls_buffer.keys()):
-                data = tool_calls_buffer[idx]
-
-                # Create object for internal logic
-                tc_obj = ToolCallMock(
-                    t_id=data['id'],
-                    name=data['function']['name'],
-                    arguments=data['function']['arguments']
-                )
-                reconstructed_tool_calls.append(tc_obj)
-
-                # Create dict for history
-                assistant_message_tool_calls.append({
-                    "id": data['id'],
-                    "type": "function",
-                    "function": {
-                        "name": data['function']['name'],
-                        "arguments": data['function']['arguments']
-                    }
-                })
-
-            # Append the Assistant's intent to call tools to the history
-            params["messages"].append({
-                "role": "assistant",
-                "content": None,
-                "tool_calls": assistant_message_tool_calls
-            })
-
-            # Recursively call completion with the reconstructed tools
-            # yield from delegates the generation of the next stream (result of tool) to this generator
-            yield from self._completion_with_tools(reconstructed_tool_calls, params)
+    def _handle_tool_call_item(self, item, params) -> None:
+        """
+        Execute a completed Responses API tool call and append both the call
+        intent and its output to *params['input']* so the LLM can continue.
+        """
+        tool_output = self._execute_tool(item.name, item.arguments)
+        params["input"].append({
+            "type": "function_call",
+            "call_id": item.call_id,
+            "name": item.name,
+            "arguments": item.arguments,
+        })
+        params["input"].append({
+            "type": "function_call_output",
+            "call_id": item.call_id,
+            "output": tool_output,
+        })
 
     def _handle_streaming_tool_calls_responses(self, response, params):
         """
-        Generator that handles streaming responses for the Responses API.
-        Streams text deltas, intercepts completed tool calls (response.output_item.done),
-        executes them, and recurses via _responses_with_tools.
+        Generator for Responses API streaming responses.
+        Yields text deltas, persists the thread ID, logs token usage, and handles
+        completed tool calls by executing them and recursing via _responses_with_tools.
         Parallel to _handle_streaming_tool_calls for the Completion API.
         """
         total_tokens = None
-        try:  # pylint: disable=R1702
+        try:
             for chunk in response:
-                # Track token usage from the response metadata
-                chunk_response = getattr(chunk, "response", None)
-                if chunk_response and hasattr(chunk_response, "usage") and chunk_response.usage:
-                    total_tokens = chunk_response.usage.total_tokens
-                elif hasattr(chunk, "usage") and chunk.usage:
-                    total_tokens = chunk.usage.total_tokens
+                total_tokens = self._get_chunk_token_usage(chunk) or total_tokens
+                self._persist_response_id(chunk)
 
-                # Persist thread ID for ongoing conversation context
-                if chunk_response and self.user_session:
-                    response_id = getattr(chunk_response, "id", None)
-                    if response_id:
-                        self.user_session.remote_response_id = response_id
-                        self.user_session.save()
+                if hasattr(chunk, "delta") and chunk.delta and chunk.delta != "{}":
+                    yield chunk.delta
 
-                # Stream text deltas, filtering out empty JSON artifacts
-                if hasattr(chunk, "delta"):
-                    yield chunk.delta if chunk.delta != "{}" else ""
-
-                # Check for completed tool call requests
-                chunk_type = getattr(chunk, "type", None)
-                if chunk_type == "response.output_item.done":
+                if getattr(chunk, "type", None) == "response.output_item.done":
                     item = chunk.item
                     if getattr(item, "type", None) == "function_call":
-                        logger.info(f"[LLM STREAM] Intercepted tool call: {item.name}")
-
-                        function_name = item.name
-                        call_id = item.call_id
-                        arguments_str = item.arguments
-
-                        # Add function call intent to history (required for API consistency)
-                        params["input"].append({
-                            "type": "function_call",
-                            "call_id": call_id,
-                            "name": function_name,
-                            "arguments": arguments_str
-                        })
-
-                        # Parse arguments and execute the local function
-                        try:
-                            function_args = json.loads(arguments_str)
-                        except json.JSONDecodeError:
-                            function_args = {}
-
-                        if function_name in AVAILABLE_TOOLS:
-                            func = AVAILABLE_TOOLS[function_name]
-                            try:
-                                tool_output = func(**function_args)
-                            except Exception as e:  # pylint: disable=broad-exception-caught
-                                tool_output = f"Error: {str(e)}"
-                        else:
-                            tool_output = "Error: Tool not found."
-                            logger.error(f"Tool '{function_name}' not found in AVAILABLE_TOOLS.")
-
-                        # Add tool output to history and re-trigger LLM response
-                        params["input"].append({
-                            "type": "function_call_output",
-                            "call_id": call_id,
-                            "output": str(tool_output)
-                        })
-
-                        # Recursively stream the new response interpreting the tool output
+                        self._handle_tool_call_item(item, params)
                         yield from self._responses_with_tools([], params)
                         return
 
-            if total_tokens is not None:
-                logger.info(f"[LLM STREAM] Tokens used: {total_tokens}")
-
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error during streaming tool calls: {e}", exc_info=True)
+            logger.error("Error during streaming tool calls: %s", e, exc_info=True)
             yield f"\n[AI Error: {e}]"
+            return
+
+        if total_tokens is not None:
+            logger.info(f"[LLM STREAM] Tokens used: {total_tokens}")
 
     def _responses_with_tools(self, tool_calls, params):
         """Handle tool calls recursively until no more tool calls are present."""
         for tool_call in tool_calls:
-            function_name = tool_call.name
-            function_to_call = AVAILABLE_TOOLS[function_name]
-            function_args = json.loads(tool_call.arguments)
-
-            function_response = function_to_call(
-                **function_args,
-            )
             params["input"].append({
                 "type": "function_call_output",
                 "call_id": tool_call.call_id,
-                "output": str(function_response)
+                "output": self._execute_tool(tool_call.name, tool_call.arguments),
             })
 
         # Call responses API with updated input

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -145,89 +145,17 @@ class LLMProcessor(LitellmProcessor):
 
         return params
 
-    def _yield_threaded_stream(self, response, params=None):
+    def _yield_threaded_stream(self, response):
         """
-        Helper generator to handle streaming logic for threaded responses.
-        Handles tool calls execution recursively during streaming.
+        Byte-encodes a streaming response for threaded conversations (Responses API).
+        Parallel to _handle_streaming_completion for the Completion API.
         """
-        total_tokens = None
-        try:  # pylint: disable=R1702
-            for chunk in response:
-                # Track token usage from the response metadata
-                chunk_response = getattr(chunk, "response", None)
-                if chunk_response and hasattr(chunk_response, "usage") and chunk_response.usage:
-                    total_tokens = chunk_response.usage.total_tokens
-                elif hasattr(chunk, "usage") and chunk.usage:
-                    total_tokens = chunk.usage.total_tokens
-
-                # Persist thread ID for ongoing conversation context
-                if chunk_response:
-                    if chunk_response is not None and self.user_session:
-                        response_id = getattr(chunk_response, "id", None)
-                        if response_id:
-                            self.user_session.remote_response_id = response_id
-                            self.user_session.save()
-
-                # Stream text deltas, filtering out empty JSON artifacts
-                if hasattr(chunk, "delta"):
-                    yield chunk.delta if chunk.delta != "{}" else ""
-
-                # Check for completed tool call requests
-                chunk_type = getattr(chunk, "type", None)
-                if chunk_type == "response.output_item.done":
-                    item = chunk.item
-                    if getattr(item, "type", None) == "function_call":
-                        logger.info(f"[LLM STREAM] Intercepted tool call: {item.name}")
-
-                        function_name = item.name
-                        call_id = item.call_id
-                        arguments_str = item.arguments
-
-                        # Add function call intent to history (required for API consistency)
-                        if params is not None:
-                            params["input"].append({
-                                "type": "function_call",
-                                "call_id": call_id,
-                                "name": function_name,
-                                "arguments": arguments_str
-                            })
-
-                        # Parse arguments and execute the local function
-                        try:
-                            function_args = json.loads(arguments_str)
-                        except json.JSONDecodeError:
-                            function_args = {}
-
-                        if function_name in AVAILABLE_TOOLS:
-                            func = AVAILABLE_TOOLS[function_name]
-                            try:
-                                tool_output = func(**function_args)
-                            except Exception as e:  # pylint: disable=broad-exception-caught
-                                tool_output = f"Error: {str(e)}"
-                        else:
-                            tool_output = "Error: Tool not found."
-
-                        if params is None:
-                            yield "\n[System Error: Missing params]".encode("utf-8")
-                            return
-
-                        # Add tool output to history and re-trigger LLM response
-                        params["input"].append({
-                            "type": "function_call_output",
-                            "call_id": call_id,
-                            "output": str(tool_output)
-                        })
-
-                        # Recursively stream the new response interpreting the tool output
-                        new_response = responses(**params)
-                        yield from self._yield_threaded_stream(new_response, params)
-                        return
-
-            if total_tokens is not None:
-                logger.info(f"[LLM STREAM] Tokens used: {total_tokens}")
-
+        try:
+            for content in response:
+                if content:
+                    yield content.encode('utf-8') if isinstance(content, str) else content
         except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error: {e}", exc_info=True)
+            logger.error(f"Error during threaded AI streaming: {e}", exc_info=True)
             yield f"\n[AI Error: {e}]".encode("utf-8")
 
     def _call_responses_wrapper(self, params, initialize=False):
@@ -238,7 +166,7 @@ class LLMProcessor(LitellmProcessor):
             response = self._responses_with_tools(tool_calls=[], params=params)
 
             if params["stream"]:
-                return self._yield_threaded_stream(response, params=params)
+                return self._yield_threaded_stream(response)
 
             response_id = getattr(response, "id", None)
             content = self._extract_response_content(response=response)
@@ -457,6 +385,87 @@ class LLMProcessor(LitellmProcessor):
             # yield from delegates the generation of the next stream (result of tool) to this generator
             yield from self._completion_with_tools(reconstructed_tool_calls, params)
 
+    def _handle_streaming_tool_calls_responses(self, response, params):
+        """
+        Generator that handles streaming responses for the Responses API.
+        Streams text deltas, intercepts completed tool calls (response.output_item.done),
+        executes them, and recurses via _responses_with_tools.
+        Parallel to _handle_streaming_tool_calls for the Completion API.
+        """
+        total_tokens = None
+        try:  # pylint: disable=R1702
+            for chunk in response:
+                # Track token usage from the response metadata
+                chunk_response = getattr(chunk, "response", None)
+                if chunk_response and hasattr(chunk_response, "usage") and chunk_response.usage:
+                    total_tokens = chunk_response.usage.total_tokens
+                elif hasattr(chunk, "usage") and chunk.usage:
+                    total_tokens = chunk.usage.total_tokens
+
+                # Persist thread ID for ongoing conversation context
+                if chunk_response and self.user_session:
+                    response_id = getattr(chunk_response, "id", None)
+                    if response_id:
+                        self.user_session.remote_response_id = response_id
+                        self.user_session.save()
+
+                # Stream text deltas, filtering out empty JSON artifacts
+                if hasattr(chunk, "delta"):
+                    yield chunk.delta if chunk.delta != "{}" else ""
+
+                # Check for completed tool call requests
+                chunk_type = getattr(chunk, "type", None)
+                if chunk_type == "response.output_item.done":
+                    item = chunk.item
+                    if getattr(item, "type", None) == "function_call":
+                        logger.info(f"[LLM STREAM] Intercepted tool call: {item.name}")
+
+                        function_name = item.name
+                        call_id = item.call_id
+                        arguments_str = item.arguments
+
+                        # Add function call intent to history (required for API consistency)
+                        params["input"].append({
+                            "type": "function_call",
+                            "call_id": call_id,
+                            "name": function_name,
+                            "arguments": arguments_str
+                        })
+
+                        # Parse arguments and execute the local function
+                        try:
+                            function_args = json.loads(arguments_str)
+                        except json.JSONDecodeError:
+                            function_args = {}
+
+                        if function_name in AVAILABLE_TOOLS:
+                            func = AVAILABLE_TOOLS[function_name]
+                            try:
+                                tool_output = func(**function_args)
+                            except Exception as e:  # pylint: disable=broad-exception-caught
+                                tool_output = f"Error: {str(e)}"
+                        else:
+                            tool_output = "Error: Tool not found."
+                            logger.error(f"Tool '{function_name}' not found in AVAILABLE_TOOLS.")
+
+                        # Add tool output to history and re-trigger LLM response
+                        params["input"].append({
+                            "type": "function_call_output",
+                            "call_id": call_id,
+                            "output": str(tool_output)
+                        })
+
+                        # Recursively stream the new response interpreting the tool output
+                        yield from self._responses_with_tools([], params)
+                        return
+
+            if total_tokens is not None:
+                logger.info(f"[LLM STREAM] Tokens used: {total_tokens}")
+
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.error(f"Error during streaming tool calls: {e}", exc_info=True)
+            yield f"\n[AI Error: {e}]"
+
     def _responses_with_tools(self, tool_calls, params):
         """Handle tool calls recursively until no more tool calls are present."""
         for tool_call in tool_calls:
@@ -473,11 +482,11 @@ class LLMProcessor(LitellmProcessor):
                 "output": str(function_response)
             })
 
-        # Call completion again with updated messages
+        # Call responses API with updated input
         response = responses(**params)
 
         if params.get("stream"):
-            return response
+            return self._handle_streaming_tool_calls_responses(response, params)
 
         new_tool_calls = self._extract_response_tool_calls(response=response)
         if new_tool_calls:

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -115,6 +115,20 @@ class LLMProcessor(LitellmProcessor):
                 tool_calls.append(item)
         return tool_calls
 
+    @staticmethod
+    def _normalize_input_to_text(input_data) -> str:
+        """
+        Coerce input_data to a plain string suitable for use as message content.
+        Handles: str, dict with 'text' key, other dicts (JSON-serialised), None.
+        """
+        if isinstance(input_data, str):
+            return input_data
+        if isinstance(input_data, dict):
+            return input_data.get("text") or ""
+        if input_data is None:
+            return ""
+        return str(input_data)
+
     def _build_response_api_params(self, system_role=None):
         """
         Build completion parameters for LiteLLM responses API.
@@ -123,7 +137,9 @@ class LLMProcessor(LitellmProcessor):
         params["stream"] = self.stream
 
         if self.chat_history:
-            self.chat_history.append({"role": "user", "content": self.input_data})
+            user_text = self._normalize_input_to_text(self.input_data)
+            if user_text:
+                self.chat_history.append({"role": "user", "content": user_text})
             params["input"] = self.chat_history
         else:
             # Initialize new thread with system role and context
@@ -155,12 +171,34 @@ class LLMProcessor(LitellmProcessor):
         """
         yield from self._handle_streaming_tool_calls_responses(response, params or {})
 
+    # Params that belong only to the Responses API and are unknown to completion().
+    _RESPONSES_API_ONLY_PARAMS = frozenset({"input", "previous_response_id", "store", "truncation"})
+
+    def _responses_params_to_completion_params(self, params: dict) -> dict:
+        """
+        Convert Responses API params to Completion API params.
+        Renames 'input' → 'messages' and drops Responses-API-only keys.
+        """
+        completion_params = {k: v for k, v in params.items()
+                             if k not in self._RESPONSES_API_ONLY_PARAMS}
+        completion_params["messages"] = params.get("input", [])
+        return completion_params
+
     def _call_responses_wrapper(self, params, initialize=False):
         """
         Wrapper around LiteLLM responses() call.
         """
         try:
             if params["stream"]:
+                if self.provider != "openai":
+                    # LiteLLM's Responses API streaming translation never surfaces
+                    # tool-call events for non-native providers (the done-event
+                    # always has type "message"). Use the Completion API path so
+                    # _handle_streaming_tool_calls can detect and execute tools.
+                    completion_params = self._responses_params_to_completion_params(params)
+                    response = self._completion_with_tools([], completion_params)
+                    return self._handle_streaming_completion(response)
+
                 raw_response = responses(**params)
                 return self._yield_threaded_stream(raw_response, params)
 

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -145,28 +145,25 @@ class LLMProcessor(LitellmProcessor):
 
         return params
 
-    def _yield_threaded_stream(self, response):
+    def _yield_threaded_stream(self, response, params=None):
         """
-        Byte-encodes a streaming response for threaded conversations (Responses API).
+        Streaming generator for threaded conversations (Responses API).
+        Parses event types, yields text deltas, logs token usage, updates the
+        user session, and handles tool calls recursively.
         Parallel to _handle_streaming_completion for the Completion API.
         """
-        try:
-            for content in response:
-                if content:
-                    yield content.encode('utf-8') if isinstance(content, str) else content
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            logger.error(f"Error during threaded AI streaming: {e}", exc_info=True)
-            yield f"\n[AI Error: {e}]".encode("utf-8")
+        yield from self._handle_streaming_tool_calls_responses(response, params or {})
 
     def _call_responses_wrapper(self, params, initialize=False):
         """
         Wrapper around LiteLLM responses() call.
         """
         try:
-            response = self._responses_with_tools(tool_calls=[], params=params)
-
             if params["stream"]:
-                return self._yield_threaded_stream(response)
+                raw_response = responses(**params)
+                return self._yield_threaded_stream(raw_response, params)
+
+            response = self._responses_with_tools(tool_calls=[], params=params)
 
             response_id = getattr(response, "id", None)
             content = self._extract_response_content(response=response)

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -4,7 +4,6 @@ Responses processor for threaded AI conversations using LiteLLM
 
 import json
 import logging
-import types
 from datetime import datetime, timezone
 
 from litellm import completion, get_responses, list_input_items, responses
@@ -12,6 +11,7 @@ from litellm import completion, get_responses, list_input_items, responses
 from openedx_ai_extensions.functions.decorators import AVAILABLE_TOOLS
 from openedx_ai_extensions.processors.llm.litellm_base_processor import LitellmProcessor
 from openedx_ai_extensions.processors.llm.providers import adapt_to_provider, after_tool_call_adaptations
+from openedx_ai_extensions.processors.llm.tool_executor import ToolExecutor
 from openedx_ai_extensions.utils import normalize_input_to_text
 
 logger = logging.getLogger(__name__)
@@ -145,7 +145,6 @@ class LLMProcessor(LitellmProcessor):
             has_user_input=has_user_input,
             user_session=self.user_session,
             input_data=self.input_data,
-            use_completion_api=(self.provider != "openai" and self.stream),
         )
 
         return params
@@ -165,10 +164,7 @@ class LLMProcessor(LitellmProcessor):
         """
         try:
             if params["stream"]:
-                if self.provider != "openai":
-                    # params was already converted to Completion API format by
-                    # adapt_to_provider (use_completion_api=True), so call
-                    # completion() directly so tool-call events are visible.
+                if "messages" in params:
                     response = self._completion_with_tools([], params)
                     return self._handle_streaming_completion(response)
 
@@ -300,71 +296,8 @@ class LLMProcessor(LitellmProcessor):
         return response
 
     # -------------------------------------------------------------------------
-    # Shared tool-execution helpers
-    # -------------------------------------------------------------------------
-
-    def _execute_tool(self, function_name: str, arguments_str: str) -> str:
-        """
-        Parse *arguments_str* as JSON, look up *function_name* in AVAILABLE_TOOLS,
-        call it, and return the result as a string.
-        Returns a descriptive error string on any failure so the caller can
-        forward it to the LLM without raising.
-        """
-        if function_name not in AVAILABLE_TOOLS:
-            logger.error("Tool '%s' not found in AVAILABLE_TOOLS.", function_name)
-            return "Error: Tool not found."
-        try:
-            function_args = json.loads(arguments_str)
-        except json.JSONDecodeError:
-            logger.error("Failed to parse JSON arguments for '%s'.", function_name)
-            return "Error: Invalid JSON arguments provided."
-        try:
-            result = AVAILABLE_TOOLS[function_name](**function_args)
-            return str(result)
-        except Exception as e:  # pylint: disable=broad-exception-caught
-            return f"Error executing tool: {e}"
-
-    # -------------------------------------------------------------------------
     # Completion API streaming helpers
     # -------------------------------------------------------------------------
-
-    @staticmethod
-    def _accumulate_tool_call_chunk(buffer: dict, tc_chunk) -> None:
-        """Merge a single streaming tool-call delta into the accumulation buffer."""
-        idx = tc_chunk.index
-        if idx not in buffer:
-            buffer[idx] = {"id": "", "type": "function", "function": {"name": "", "arguments": ""}}
-        if tc_chunk.id:
-            buffer[idx]["id"] += tc_chunk.id
-        if tc_chunk.function:
-            buffer[idx]["function"]["name"] += tc_chunk.function.name or ""
-            buffer[idx]["function"]["arguments"] += tc_chunk.function.arguments or ""
-
-    @staticmethod
-    def _reconstruct_tool_calls(buffer: dict):
-        """
-        Convert the chunk accumulation buffer into:
-        - a list of SimpleNamespace objects accepted by _completion_with_tools
-        - a list of dicts for the assistant history message
-        """
-        tool_call_objects = []
-        assistant_tool_calls = []
-        for idx in sorted(buffer):
-            data = buffer[idx]
-            fn = data["function"]
-            tool_call_objects.append(
-                types.SimpleNamespace(
-                    id=data["id"],
-                    type="function",
-                    function=types.SimpleNamespace(name=fn["name"], arguments=fn["arguments"]),
-                )
-            )
-            assistant_tool_calls.append({
-                "id": data["id"],
-                "type": "function",
-                "function": {"name": fn["name"], "arguments": fn["arguments"]},
-            })
-        return tool_call_objects, assistant_tool_calls
 
     def _handle_streaming_tool_calls(self, response, params):
         """
@@ -379,12 +312,12 @@ class LLMProcessor(LitellmProcessor):
             if delta.content:
                 yield chunk
             for tc_chunk in (delta.tool_calls or []):
-                self._accumulate_tool_call_chunk(tool_calls_buffer, tc_chunk)
+                ToolExecutor.accumulate_tool_call_chunk(tool_calls_buffer, tc_chunk)
 
         if not tool_calls_buffer:
             return
 
-        tool_call_objects, assistant_tool_calls = self._reconstruct_tool_calls(tool_calls_buffer)
+        tool_call_objects, assistant_tool_calls = ToolExecutor.reconstruct_tool_calls(tool_calls_buffer)
         params["messages"].append({
             "role": "assistant",
             "content": None,
@@ -421,7 +354,7 @@ class LLMProcessor(LitellmProcessor):
         Execute a completed Responses API tool call and append both the call
         intent and its output to *params['input']* so the LLM can continue.
         """
-        tool_output = self._execute_tool(item.name, item.arguments)
+        tool_output = ToolExecutor.execute_tool(item.name, item.arguments)
         params["input"].append({
             "type": "function_call",
             "call_id": item.call_id,
@@ -471,7 +404,7 @@ class LLMProcessor(LitellmProcessor):
             params["input"].append({
                 "type": "function_call_output",
                 "call_id": tool_call.call_id,
-                "output": self._execute_tool(tool_call.name, tool_call.arguments),
+                "output": ToolExecutor.execute_tool(tool_call.name, tool_call.arguments),
             })
 
         # Call responses API with updated input

--- a/backend/openedx_ai_extensions/processors/llm/providers/__init__.py
+++ b/backend/openedx_ai_extensions/processors/llm/providers/__init__.py
@@ -6,7 +6,7 @@ Provider-specific quirks and adaptations for different LLM providers.
 # TODO: refactor this module to make it more extensible for future providers
 def adapt_to_provider(
         provider, params, *, has_user_input=True, user_session=None,
-        input_data=None, use_completion_api=False):
+        input_data=None):
     """
     Apply provider-specific modifications to API call parameters.
 
@@ -14,17 +14,19 @@ def adapt_to_provider(
     scattered throughout the codebase (e.g., OpenAI-specific threading,
     Anthropic's requirement for user messages).
 
+    For non-OpenAI providers that are streaming with Responses API params
+    (i.e. ``input`` key present), the parameters are automatically converted
+    to Completion API format (``messages``) because LiteLLM's Responses API
+    streaming translation does not surface tool-call events correctly for
+    those providers.  Callers can check for the ``"messages"`` key in the
+    returned dict to decide whether to use the Completion API path.
+
     Args:
         provider (str): The LLM provider name (e.g., 'openai', 'anthropic')
         params (dict): The parameters dictionary to modify
         has_user_input (bool): Whether the conversation includes user input
         user_session: Optional user session for threading support
         input_data: Optional input data for continuing conversations
-        use_completion_api (bool): When True, convert Responses API params
-            (``input``) to Completion API format (``messages``) and drop
-            Responses-API-only keys.  Used for non-OpenAI streaming where
-            LiteLLM's Responses API translation does not surface tool-call
-            events correctly.
 
     Returns:
         dict: Modified parameters with provider-specific adaptations applied
@@ -54,9 +56,10 @@ def adapt_to_provider(
                 elif "messages" in params:
                     params["messages"].append({"role": "user", "content": user_prompt})
 
-    if use_completion_api and "input" in params:
-        # Convert Responses API shape → Completion API shape so that
-        # completion() and _completion_with_tools() can be called directly.
+    if provider != "openai" and params.get("stream") and "input" in params:
+        # Non-OpenAI providers: convert Responses API shape → Completion API
+        # shape so that completion() / _completion_with_tools() can be called
+        # directly, ensuring tool-call events are visible during streaming.
         params["messages"] = params.pop("input")
         for key in ("previous_response_id", "store", "truncation"):
             params.pop(key, None)

--- a/backend/openedx_ai_extensions/processors/llm/providers/__init__.py
+++ b/backend/openedx_ai_extensions/processors/llm/providers/__init__.py
@@ -4,7 +4,9 @@ Provider-specific quirks and adaptations for different LLM providers.
 
 
 # TODO: refactor this module to make it more extensible for future providers
-def adapt_to_provider(provider, params, has_user_input=True, user_session=None, input_data=None):
+def adapt_to_provider(
+        provider, params, *, has_user_input=True, user_session=None,
+        input_data=None, use_completion_api=False):
     """
     Apply provider-specific modifications to API call parameters.
 
@@ -18,6 +20,11 @@ def adapt_to_provider(provider, params, has_user_input=True, user_session=None, 
         has_user_input (bool): Whether the conversation includes user input
         user_session: Optional user session for threading support
         input_data: Optional input data for continuing conversations
+        use_completion_api (bool): When True, convert Responses API params
+            (``input``) to Completion API format (``messages``) and drop
+            Responses-API-only keys.  Used for non-OpenAI streaming where
+            LiteLLM's Responses API translation does not surface tool-call
+            events correctly.
 
     Returns:
         dict: Modified parameters with provider-specific adaptations applied
@@ -46,6 +53,13 @@ def adapt_to_provider(provider, params, has_user_input=True, user_session=None, 
                     params["input"].append({"role": "user", "content": user_prompt})
                 elif "messages" in params:
                     params["messages"].append({"role": "user", "content": user_prompt})
+
+    if use_completion_api and "input" in params:
+        # Convert Responses API shape → Completion API shape so that
+        # completion() and _completion_with_tools() can be called directly.
+        params["messages"] = params.pop("input")
+        for key in ("previous_response_id", "store", "truncation"):
+            params.pop(key, None)
 
     return params
 

--- a/backend/openedx_ai_extensions/processors/llm/tool_executor.py
+++ b/backend/openedx_ai_extensions/processors/llm/tool_executor.py
@@ -1,0 +1,97 @@
+"""
+Stateless helpers for executing LLM tool calls and accumulating
+streaming tool-call deltas.
+
+Extracted from LLMProcessor so they can be tested in isolation
+and reused by any processor that needs function-calling support.
+"""
+
+import json
+import logging
+import types
+
+from openedx_ai_extensions.functions.decorators import AVAILABLE_TOOLS
+
+logger = logging.getLogger(__name__)
+
+
+class ToolExecutor:
+    """
+    Pure-logic helper for LLM tool / function-call handling.
+
+    Every method is either a static method or a class method — the class
+    carries **no instance state**.  Instantiate it (or call the methods
+    directly via the class) from any processor that needs tool execution
+    or streaming-delta accumulation.
+    """
+
+    # -----------------------------------------------------------------
+    # Tool execution
+    # -----------------------------------------------------------------
+
+    @staticmethod
+    def execute_tool(function_name: str, arguments_str: str) -> str:
+        """
+        Parse *arguments_str* as JSON, look up *function_name* in
+        ``AVAILABLE_TOOLS``, call it, and return the result as a string.
+
+        Returns a descriptive error string on any failure so the caller
+        can forward it to the LLM without raising.
+        """
+        if function_name not in AVAILABLE_TOOLS:
+            logger.error("Tool '%s' not found in AVAILABLE_TOOLS.", function_name)
+            return "Error: Tool not found."
+        try:
+            function_args = json.loads(arguments_str)
+        except json.JSONDecodeError:
+            logger.error("Failed to parse JSON arguments for '%s'.", function_name)
+            return "Error: Invalid JSON arguments provided."
+        try:
+            result = AVAILABLE_TOOLS[function_name](**function_args)
+            return str(result)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            return f"Error executing tool: {e}"
+
+    # -----------------------------------------------------------------
+    # Streaming tool-call delta accumulation (Completion API)
+    # -----------------------------------------------------------------
+
+    @staticmethod
+    def accumulate_tool_call_chunk(buffer: dict, tc_chunk) -> None:
+        """Merge a single streaming tool-call delta into *buffer*."""
+        idx = tc_chunk.index
+        if idx not in buffer:
+            buffer[idx] = {"id": "", "type": "function", "function": {"name": "", "arguments": ""}}
+        if tc_chunk.id:
+            buffer[idx]["id"] += tc_chunk.id
+        if tc_chunk.function:
+            buffer[idx]["function"]["name"] += tc_chunk.function.name or ""
+            buffer[idx]["function"]["arguments"] += tc_chunk.function.arguments or ""
+
+    @staticmethod
+    def reconstruct_tool_calls(buffer: dict):
+        """
+        Convert the chunk-accumulation *buffer* into:
+
+        * a list of ``SimpleNamespace`` objects (compatible with
+          ``_completion_with_tools``)
+        * a list of plain dicts suitable for the assistant history message
+        """
+        tool_call_objects = []
+        assistant_tool_calls = []
+        for idx in sorted(buffer):
+            data = buffer[idx]
+            fn = data["function"]
+            tool_call_objects.append(
+                types.SimpleNamespace(
+                    id=data["id"],
+                    type="function",
+                    function=types.SimpleNamespace(name=fn["name"], arguments=fn["arguments"]),
+                )
+            )
+            assistant_tool_calls.append({
+                "id": data["id"],
+                "type": "function",
+                "function": {"name": fn["name"], "arguments": fn["arguments"]},
+            })
+        return tool_call_objects, assistant_tool_calls

--- a/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
@@ -267,10 +267,19 @@ class SubmissionProcessor:
         """
         if self.user_session.local_submission_id:
             messages, _ = self._process_messages(use_max_context=False)
+            cleaned = []
             for msg in messages:
                 if isinstance(msg, dict):
                     msg.pop("timestamp", None)
-            return messages
+                    # Only validate content for role-based messages (user/assistant/system).
+                    # Function call/output items use other fields (type, call_id, etc.) and
+                    # legitimately have no content field — never filter those out.
+                    if "role" in msg:
+                        content = msg.get("content")
+                        if not isinstance(content, str) or not content:
+                            continue
+                cleaned.append(msg)
+            return cleaned
         else:
             return None
 

--- a/backend/openedx_ai_extensions/utils.py
+++ b/backend/openedx_ai_extensions/utils.py
@@ -5,6 +5,21 @@ Utility functions for Open edX AI Extensions.
 from types import GeneratorType
 
 
+def normalize_input_to_text(input_data) -> str:
+    """
+    Coerce input_data to a plain string suitable for use as message content.
+
+    Handles: str, dict with 'text' key, other dicts (JSON-serialised), None.
+    """
+    if isinstance(input_data, str):
+        return input_data
+    if isinstance(input_data, dict):
+        return input_data.get("text") or ""
+    if input_data is None:
+        return ""
+    return str(input_data)
+
+
 def is_generator(result):
     """
     Check if the given object is a generator.

--- a/backend/openedx_ai_extensions/workflows/orchestrators/threaded_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/threaded_orchestrator.py
@@ -6,7 +6,7 @@ import json
 import logging
 
 from openedx_ai_extensions.processors import LLMProcessor, OpenEdXProcessor
-from openedx_ai_extensions.utils import is_generator
+from openedx_ai_extensions.utils import is_generator, normalize_input_to_text
 from openedx_ai_extensions.xapi.constants import EVENT_NAME_WORKFLOW_INITIALIZED, EVENT_NAME_WORKFLOW_INTERACTED
 
 from .session_based_orchestrator import SessionBasedOrchestrator
@@ -82,7 +82,7 @@ class ThreadedLLMResponse(SessionBasedOrchestrator):
             # 2. Save History (Post-Stream Phase)
             # This executes after the view has consumed the last chunk
             final_response = "".join(full_response_text)
-            user_text = LLMProcessor._normalize_input_to_text(input_data)
+            user_text = normalize_input_to_text(input_data)
 
             messages = [{"role": "assistant", "content": final_response}]
             if user_text:
@@ -168,7 +168,7 @@ class ThreadedLLMResponse(SessionBasedOrchestrator):
         messages = [
             {"role": "assistant", "content": llm_result.get("response", "")},
         ]
-        user_text = LLMProcessor._normalize_input_to_text(input_data)
+        user_text = normalize_input_to_text(input_data)
         if user_text:
             messages.insert(0, {"role": "user", "content": user_text})
 

--- a/backend/openedx_ai_extensions/workflows/orchestrators/threaded_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/threaded_orchestrator.py
@@ -82,11 +82,11 @@ class ThreadedLLMResponse(SessionBasedOrchestrator):
             # 2. Save History (Post-Stream Phase)
             # This executes after the view has consumed the last chunk
             final_response = "".join(full_response_text)
+            user_text = LLMProcessor._normalize_input_to_text(input_data)
 
-            messages = [
-                {"role": "user", "content": input_data},
-                {"role": "assistant", "content": final_response},
-            ]
+            messages = [{"role": "assistant", "content": final_response}]
+            if user_text:
+                messages.insert(0, {"role": "user", "content": user_text})
 
             # Re-inject system messages if this was a new thread (and not OpenAI)
             if llm_processor.get_provider() != "openai" and initial_system_msgs:
@@ -168,8 +168,9 @@ class ThreadedLLMResponse(SessionBasedOrchestrator):
         messages = [
             {"role": "assistant", "content": llm_result.get("response", "")},
         ]
-        if input_data:
-            messages.insert(0, {"role": "user", "content": input_data})
+        user_text = LLMProcessor._normalize_input_to_text(input_data)
+        if user_text:
+            messages.insert(0, {"role": "user", "content": user_text})
 
         if llm_processor.get_provider() != "openai":
             system_messages = llm_result.get("system_messages", {})

--- a/backend/tests/test_litellm_base_processor.py
+++ b/backend/tests/test_litellm_base_processor.py
@@ -578,39 +578,6 @@ def test_non_string_provider_raises_error(mock_settings):  # pylint: disable=unu
 
 
 # ============================================================================
-# Streaming with Tools Tests
-# ============================================================================
-
-
-@patch.object(settings, "AI_EXTENSIONS", new_callable=lambda: {
-    "default": {
-        "MODEL": "openai/gpt-4",
-    }
-})
-@pytest.mark.django_db
-def test_streaming_with_tools_disables_streaming(mock_settings):  # pylint: disable=unused-argument
-    """
-    Test that streaming is disabled when tools are enabled.
-    """
-    config = {
-        "LitellmProcessor": {
-            "stream": True,
-            "enabled_tools": ["roll_dice"],
-        }
-    }
-    with patch('openedx_ai_extensions.processors.llm.litellm_base_processor.logger') as mock_logger:
-        processor = LitellmProcessor(config=config, user_session=None)
-
-        # Verify streaming was disabled
-        assert processor.stream is False
-
-        # Verify warning was logged
-        mock_logger.warning.assert_called_once_with(
-            "Streaming responses with tools is not supported; disabling streaming."
-        )
-
-
-# ============================================================================
 # MCP Configs Tests
 # ============================================================================
 

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -2,6 +2,7 @@
 Tests for the LLMProcessor module.
 """
 # pylint: disable=redefined-outer-name,protected-access
+import types
 import unittest
 from unittest.mock import Mock, patch
 
@@ -1236,6 +1237,75 @@ def test_streaming_tool_execution_recursion(
         assert tool_msg["content"] == "tool_result_value"
         assert tool_msg["name"] == "mock_tool"
 
+
+# ============================================================================
+# _completion_with_tools Error Path Tests
+# ============================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_completion_with_tools_unknown_tool_is_skipped(
+    mock_completion, llm_processor  # pylint: disable=redefined-outer-name
+):
+    """
+    When a tool call references a function not in AVAILABLE_TOOLS the call is
+    silently skipped (logged) and completion proceeds without a tool message.
+    """
+    mock_completion.return_value = Mock(
+        choices=[Mock(message=Mock(content="done", tool_calls=None))],
+        usage=Mock(total_tokens=5),
+    )
+    unknown_call = types.SimpleNamespace(
+        id="call_x",
+        function=types.SimpleNamespace(name="unknown_tool", arguments='{}'),
+    )
+    params = {
+        "stream": False,
+        "messages": [{"role": "system", "content": "sys"}],
+        "model": "openai/gpt-4",
+    }
+    # pylint: disable=protected-access
+    response = llm_processor._completion_with_tools([unknown_call], params)
+
+    # No tool message should have been appended
+    assert all(m.get("role") != "tool" for m in params["messages"])
+    mock_completion.assert_called_once()
+    assert response.choices[0].message.content == "done"
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_completion_with_tools_json_decode_error(
+    mock_completion, llm_processor  # pylint: disable=redefined-outer-name
+):
+    """
+    When a tool call carries malformed JSON arguments, json.JSONDecodeError is
+    caught, an error string is passed as the tool result, and completion
+    continues normally.
+    """
+    mock_tool = Mock(return_value="ok")
+    mock_completion.return_value = Mock(
+        choices=[Mock(message=Mock(content="done", tool_calls=None))],
+        usage=Mock(total_tokens=5),
+    )
+    bad_json_call = types.SimpleNamespace(
+        id="call_bad",
+        function=types.SimpleNamespace(name="mock_tool", arguments="{INVALID JSON}"),
+    )
+    params = {
+        "stream": False,
+        "messages": [{"role": "system", "content": "sys"}],
+        "model": "openai/gpt-4",
+    }
+    with patch.dict(AVAILABLE_TOOLS, {"mock_tool": mock_tool}):
+        # pylint: disable=protected-access
+        llm_processor._completion_with_tools([bad_json_call], params)
+
+    tool_msg = next((m for m in params["messages"] if m.get("role") == "tool"), None)
+    assert tool_msg is not None
+    assert "Error" in tool_msg["content"]
+    mock_tool.assert_not_called()
 
 # ============================================================================
 # Threaded Streaming & Tool Call Tests (Responses API)

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -1063,9 +1063,11 @@ class TestLLMProcessorInit(unittest.TestCase):
         }
         processor = LLMProcessor(config, user_session, extra_params=extra_params)    # pylint: disable=unused-variable
         mock_litellm_init.assert_called_once_with(config, user_session, extra_params)
+
 # ============================================================================
 # Streaming Tool Call Tests
 # ============================================================================
+
 
 class MockToolStreamChunk:
     """
@@ -1177,6 +1179,7 @@ def test_streaming_tool_execution_recursion(
 # ============================================================================
 # Threaded Streaming & Tool Call Tests (Responses API)
 # ============================================================================
+
 
 class MockResponseUsage:
     """Helper to mock usage in Responses API."""

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -295,9 +295,9 @@ def test_chat_with_context_streaming_non_openai_uses_completion(
     completion() instead of responses() when streaming=True.
 
     LiteLLM's Responses API streaming translation does not surface tool-call
-    events for non-native providers, so adapt_to_provider converts the params
-    to Completion API format (input → messages) and _call_responses_wrapper
-    falls through to the completion path.
+    events for non-native providers, so adapt_to_provider automatically converts
+    the params to Completion API format (input → messages) and
+    _call_responses_wrapper detects the 'messages' key to take the completion path.
 
     The result must be a generator of encoded bytes (same as summarize_content).
     """

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -10,8 +10,8 @@ from django.contrib.auth import get_user_model
 from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator
 
-from openedx_ai_extensions.processors.llm.llm_processor import LLMProcessor
 from openedx_ai_extensions.functions.decorators import AVAILABLE_TOOLS
+from openedx_ai_extensions.processors.llm.llm_processor import LLMProcessor
 from openedx_ai_extensions.workflows.models import AIWorkflowProfile, AIWorkflowScope, AIWorkflowSession
 
 User = get_user_model()
@@ -1095,8 +1095,8 @@ class MockToolStreamChunk:
 
 
 @pytest.mark.django_db
-@patch("openedx_ai_extensions.processors.llm_processor.completion")
-@patch("openedx_ai_extensions.processors.llm_processor.adapt_to_provider")
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+@patch("openedx_ai_extensions.processors.llm.llm_processor.adapt_to_provider")
 def test_streaming_tool_execution_recursion(
     mock_adapt, mock_completion, llm_processor  # pylint: disable=redefined-outer-name
 ):
@@ -1172,3 +1172,114 @@ def test_streaming_tool_execution_recursion(
         assert tool_msg["tool_call_id"] == "call_123"
         assert tool_msg["content"] == "tool_result_value"
         assert tool_msg["name"] == "mock_tool"
+
+
+# ============================================================================
+# Threaded Streaming & Tool Call Tests (Responses API)
+# ============================================================================
+
+class MockResponseUsage:
+    """Helper to mock usage in Responses API."""
+
+    def __init__(self, total):
+        self.total_tokens = total
+
+
+class MockResponsesChunk:
+    """Helper to mock chunks specifically for the Responses API stream."""
+
+    def __init__(self, chunk_type, **kwargs):
+        self.type = chunk_type
+        self.delta = kwargs.get("delta")
+        self.item = kwargs.get("item")
+        self.response = None
+        usage_total = kwargs.get("usage_total")
+        response_id = kwargs.get("response_id")
+        if usage_total or response_id:
+            self.response = Mock(
+                usage=MockResponseUsage(usage_total) if usage_total else None,
+                id=response_id
+            )
+        if usage_total:
+            self.usage = MockResponseUsage(usage_total)
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.logger")
+@patch("openedx_ai_extensions.processors.llm.llm_processor.responses")
+def test_yield_threaded_stream_text_and_tokens(
+    mock_responses, mock_logger, llm_processor, user_session  # pylint: disable=W0621,W0613
+):
+    """
+    Test verifies text yielding and ensures token usage is LOGGED properly.
+    """
+    chunks = [
+        MockResponsesChunk("response.created", response_id="resp_123"),
+        MockResponsesChunk("response.delta", delta="Hello"),
+        MockResponsesChunk("response.delta", delta="{}"),
+        MockResponsesChunk("response.delta", delta=" world"),
+        MockResponsesChunk("response.completed", usage_total=42)
+    ]
+    # pylint: disable=protected-access
+    generator = llm_processor._yield_threaded_stream(iter(chunks))
+    results = list(generator)
+
+    assert "Hello" in results
+    assert " world" in results
+    assert "{}" not in results
+
+    user_session.refresh_from_db()
+    assert user_session.remote_response_id == "resp_123"
+
+    found_token_log = any(
+        "Tokens used: 42" in str(args)
+        for args, _ in mock_logger.info.call_args_list
+    )
+    assert found_token_log, "Total tokens (42) were not logged as expected."
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.responses")
+def test_yield_threaded_stream_recursive_tool_call(
+    mock_responses, llm_processor   # pylint: disable=W0621
+):
+    """
+    Test recursive tool execution in threaded stream.
+    """
+    mock_dice_roll = Mock(return_value="[6]")
+
+    with patch.dict("openedx_ai_extensions.functions.decorators.AVAILABLE_TOOLS",
+                    {"roll_dice": mock_dice_roll}):
+        item_mock = Mock(
+            type="function_call",
+            call_id="call_abc",
+            arguments='{"n_dice": 1}'
+        )
+        item_mock.name = "roll_dice"
+
+        stream_a = [
+            MockResponsesChunk("response.output_item.done", item=item_mock)
+        ]
+
+        stream_b = [
+            MockResponsesChunk("response.delta", delta="You rolled a 6")
+        ]
+
+        mock_responses.return_value = iter(stream_b)
+
+        params = {"input": [{"role": "user", "content": "Roll dice"}], "stream": True}
+        # pylint: disable=protected-access
+        generator = llm_processor._yield_threaded_stream(iter(stream_a), params=params)
+        results = list(generator)
+
+        assert "Error: Tool not found." not in str(results)
+
+        assert "You rolled a 6" in results
+
+        mock_dice_roll.assert_called_once_with(n_dice=1)
+
+        history = params["input"]
+        assert history[1]["type"] == "function_call"
+        assert history[1]["name"] == "roll_dice"
+
+        mock_responses.assert_called_once()

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -284,6 +284,67 @@ def test_chat_with_context_streaming(
 
 
 @pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.responses")
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_chat_with_context_streaming_non_openai_uses_completion(
+    mock_completion, mock_responses, user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that chat_with_context for a non-OpenAI provider (e.g. Anthropic) calls
+    completion() instead of responses() when streaming=True.
+
+    LiteLLM's Responses API streaming translation does not surface tool-call
+    events for non-native providers, so adapt_to_provider converts the params
+    to Completion API format (input → messages) and _call_responses_wrapper
+    falls through to the completion path.
+
+    The result must be a generator of encoded bytes (same as summarize_content).
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "anthropic/claude-3-5-sonnet",
+            "API_KEY": "test-anthropic-key",
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "chat_with_context",
+            "stream": True,
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+    processor.stream = True
+    processor.extra_params.pop("tools", None)
+
+    chunks = [
+        MockChunk("Hi", is_stream=True),
+        MockChunk(" there", is_stream=True),
+    ]
+    mock_completion.return_value = iter(chunks)
+
+    generator = processor.process(
+        context="Course Context",
+        input_data="Hello Anthropic",
+        chat_history=[]
+    )
+    results = list(generator)
+
+    # completion() must have been used — responses() must NOT be called
+    mock_responses.assert_not_called()
+    mock_completion.assert_called_once()
+
+    # Params passed to completion() must use 'messages', not 'input'
+    call_kwargs = mock_completion.call_args[1]
+    assert "messages" in call_kwargs, "Expected Completion API format (messages key)"
+    assert "input" not in call_kwargs, "Responses API key 'input' must not be present"
+
+    # Output is encoded bytes (handled by _handle_streaming_completion)
+    assert results[0] == b"Hi"
+    assert results[1] == b" there"
+
+
+@pytest.mark.django_db
 @patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
 def test_summarize_content_streaming(
     mock_completion, llm_processor  # pylint: disable=redefined-outer-name

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -11,6 +11,7 @@ from opaque_keys.edx.keys import CourseKey
 from opaque_keys.edx.locator import BlockUsageLocator
 
 from openedx_ai_extensions.processors.llm.llm_processor import LLMProcessor
+from openedx_ai_extensions.functions.decorators import AVAILABLE_TOOLS
 from openedx_ai_extensions.workflows.models import AIWorkflowProfile, AIWorkflowScope, AIWorkflowSession
 
 User = get_user_model()
@@ -91,8 +92,9 @@ def llm_processor(user_session, settings):  # pylint: disable=redefined-outer-na
 
 class MockDelta:
     """Mock for the delta object in a streaming chunk."""
-    def __init__(self, content):
+    def __init__(self, content, tool_calls=None):
         self.content = content
+        self.tool_calls = tool_calls
 
 
 class MockChoice:
@@ -130,6 +132,26 @@ class MockChunk:
                     ]
                 )
             ]
+
+
+class MockUsage:
+    """Mock for usage statistics."""
+    def __init__(self, total_tokens=10):
+        self.total_tokens = total_tokens
+
+
+class MockStreamChunk:
+    """Mock for a streaming chunk."""
+    def __init__(self, content, is_delta=True):
+        self.usage = MockUsage(total_tokens=5)
+        self.delta = None
+        self.choices = []
+
+        if is_delta:
+            mock_delta = MockDelta(content)
+            self.choices = [MockChoice(delta=mock_delta)]
+            self.delta = mock_delta
+            self.response = Mock(id="stream-id-123")
 
 
 # ============================================================================
@@ -1041,3 +1063,112 @@ class TestLLMProcessorInit(unittest.TestCase):
         }
         processor = LLMProcessor(config, user_session, extra_params=extra_params)    # pylint: disable=unused-variable
         mock_litellm_init.assert_called_once_with(config, user_session, extra_params)
+# ============================================================================
+# Streaming Tool Call Tests
+# ============================================================================
+
+class MockToolStreamChunk:
+    """
+    Helper for simulating tool call chunks in a stream.
+    Structure follows: chunk.choices[0].delta.tool_calls[...]
+    """
+
+    def __init__(self, index, tool_id=None, name=None, arguments=None):
+        self.usage = MockUsage(total_tokens=5)
+
+        # 1. Create the function mock
+        func_mock = Mock()
+        func_mock.name = name
+        func_mock.arguments = arguments
+
+        # 2. Create the tool_call mock
+        tool_call_mock = Mock()
+        tool_call_mock.index = index
+        tool_call_mock.id = tool_id
+        tool_call_mock.function = func_mock
+
+        # Construct the delta
+        delta = MockDelta(content=None, tool_calls=[tool_call_mock])
+
+        # Construct the choice
+        self.choices = [MockChoice(delta=delta)]
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm_processor.completion")
+@patch("openedx_ai_extensions.processors.llm_processor.adapt_to_provider")
+def test_streaming_tool_execution_recursion(
+    mock_adapt, mock_completion, llm_processor  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that streaming correctly handles tool calls:
+    1. Buffers tool call chunks.
+    2. Executes the tool.
+    3. Recursively calls completion with tool output.
+    4. Yields the final content chunks.
+    """
+    # 1. Setup
+    mock_adapt.side_effect = lambda provider, params, **kwargs: params
+
+    # Configure processor for streaming + custom function calling
+    llm_processor.config["function"] = "summarize_content"  # Uses _call_completion_wrapper
+    llm_processor.config["stream"] = True
+    llm_processor.stream = True
+    llm_processor.extra_params["tools"] = ["mock_tool"]  # Needs to pass check in init if strict, but mainly for logic
+
+    # 2. Define a Mock Tool
+    mock_tool_func = Mock(return_value="tool_result_value")
+
+    # Patch the global AVAILABLE_TOOLS to include our mock
+    with patch.dict(AVAILABLE_TOOLS, {"mock_tool": mock_tool_func}):
+        # 3. Define Stream Sequences
+
+        # Sequence 1: The Model decides to call "mock_tool" with args {"arg": "val"}
+        # Split into multiple chunks to test buffering logic
+        tool_chunks = [
+            # Chunk 1: ID and Name
+            MockToolStreamChunk(index=0, tool_id="call_123", name="mock_tool"),
+            # Chunk 2: Start of args
+            MockToolStreamChunk(index=0, arguments='{"arg":'),
+            # Chunk 3: End of args
+            MockToolStreamChunk(index=0, arguments=' "val"}'),
+        ]
+
+        # Sequence 2: The Model sees the tool result and generates final text
+        content_chunks = [
+            MockStreamChunk("Result "),
+            MockStreamChunk("is "),
+            MockStreamChunk("tool_result_value"),
+        ]
+
+        # Configure completion to return the first sequence, then the second
+        mock_completion.side_effect = [iter(tool_chunks), iter(content_chunks)]
+
+        # 4. Execute
+        generator = llm_processor.process(context="Ctx")
+        results = list(generator)
+
+        # 5. Assertions
+
+        # Check final output (byte encoded by _handle_streaming_completion)
+        assert b"Result " in results
+        assert b"is " in results
+        assert b"tool_result_value" in results
+
+        # Check Tool Execution
+        mock_tool_func.assert_called_once_with(arg="val")
+
+        # Check Recursion (completion called twice)
+        assert mock_completion.call_count == 2
+
+        # Verify second call included the tool output
+        second_call_kwargs = mock_completion.call_args_list[1][1]
+        messages = second_call_kwargs["messages"]
+
+        # Should have: System, (Context/User), Assistant(ToolCall), Tool(Result)
+        # Finding the tool message
+        tool_msg = next((m for m in messages if m.get("role") == "tool"), None)
+        assert tool_msg is not None
+        assert tool_msg["tool_call_id"] == "call_123"
+        assert tool_msg["content"] == "tool_result_value"
+        assert tool_msg["name"] == "mock_tool"


### PR DESCRIPTION
Changes taken from @Pavilion4ik's PR #102 

ORIGINAL COVERLETTER:

This PR refactors the LiteLLM-based processors to support streaming responses even when OpenAI function calling (tools) is enabled. Specifically, it includes:

chunk aggregation: Added logic to buffer streaming chunks in LLMProcessor, reconstruct fragmented tool call arguments, and execute the tools once the stream for that specific call is complete.

Recursive Streaming: Implemented yield from recursion in _handle_streaming_tool_calls to allow the LLM to call a function, receive the output, and continue streaming the final text response to the user.

Educator Processor Update: enabled streaming in EducatorAssistantProcessor for general chat, while explicitly forcing non-streaming mode for generate_quiz_questions (since it requires full response JSON validation and retry logic).

Unit Tests: Added comprehensive tests to verify that streaming works correctly with single and multiple tool calls.

Why?
Previously, LitellmProcessor explicitly disabled streaming if any tools were configured. This resulted in a poor User Experience (UX) where users had to wait for the entire generation to finish before seeing any text, simply because a tool might have been used. This change allows for a "best of both worlds" scenario: immediate feedback via streaming for text responses, and correct execution of background functions when the model decides to use them.

---------------------------------------------------------

## How to test

1. Use predefined which uses functions (e. g. `examples/openai/chat_functions.json `or `examples/openai/box_functions.json`) and add `"stream": true`
2. Test you can ask AI to call functions with streaming