### PR TITLE
Fmo/npm dist

### DIFF
--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,5 +1,6 @@
 precommit:
 	npm run lint
+	npm run types
 	npm audit
 
 requirements:
@@ -13,3 +14,15 @@ build:
 	cp ./package.json ./dist/package.json
 	cp ./LICENSE ./dist/LICENSE 2>/dev/null || cp ../LICENSE ./dist/LICENSE 2>/dev/null || true
 	cp ./README.md ./dist/README.md
+
+.PHONY: validate
+validate:
+	npm run lint -- --max-warnings 0
+	npm run types
+	npm test
+	make build
+
+.PHONY: validate.ci
+validate.ci:
+	npm ci
+	make validate

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -8,10 +8,9 @@ requirements:
 
 build:
 	rm -rf ./dist
-	./node_modules/.bin/fedx-scripts babel src --out-dir dist --source-maps --ignore **/*.test.jsx,**/*.test.js,**/setupTest.js --copy-files
-	@# --copy-files will bring in everything else that wasn't processed by babel. Remove what we don't want.
-	@find dist -name '*.test.js*' -delete
-	cp ./package.json ./dist/package.json
+	./node_modules/.bin/fedx-scripts babel src --out-dir dist --source-maps --extensions '.js,.jsx,.ts,.tsx' --ignore '**/*.test.jsx,**/*.test.js,**/*.test.ts,**/*.test.tsx,**/setupTest.js,**/setupTest.ts' --copy-files
+	@find dist -name '*.test.*' -delete
+	./node_modules/.bin/tsc -p tsconfig.build.json --emitDeclarationOnly
 	cp ./LICENSE ./dist/LICENSE 2>/dev/null || cp ../LICENSE ./dist/LICENSE 2>/dev/null || true
 	cp ./README.md ./dist/README.md
 

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,0 +1,1 @@
+module.exports = require('@openedx/frontend-build/config/babel-typescript.config.js');

--- a/frontend/babel.config.js
+++ b/frontend/babel.config.js
@@ -1,1 +1,1 @@
-module.exports = require('@openedx/frontend-build/config/babel-typescript.config.js');
+module.exports = require('@openedx/frontend-build/config/babel-typescript.config');

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
+      "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/openedx-ai-extensions-ui",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,17 @@
   "version": "1.1.0",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": [
+    "dist/"
+  ],
+  "sideEffects": false,
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openedx/openedx-ai-extensions.git"
@@ -12,6 +23,7 @@
   ],
   "scripts": {
     "build": "make build",
+    "prepublishOnly": "npm run build",
     "lint": "fedx-scripts eslint --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "fedx-scripts eslint --fix --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "test": "fedx-scripts jest --coverage --passWithNoTests",

--- a/frontend/src/ai-extensions-settings/types.ts
+++ b/frontend/src/ai-extensions-settings/types.ts
@@ -1,8 +1,0 @@
-/**
- * Types for AI Extensions Settings
- *
- * Badge-specific types (BadgeFormData, GeneratedBadge, etc.) have been moved
- * to the openedx-ai-badges plugin where they belong.
- */
-
-export {};

--- a/frontend/src/ai-extensions-settings/types.ts
+++ b/frontend/src/ai-extensions-settings/types.ts
@@ -1,0 +1,8 @@
+/**
+ * Types for AI Extensions Settings
+ *
+ * Badge-specific types (BadgeFormData, GeneratedBadge, etc.) have been moved
+ * to the openedx-ai-badges plugin where they belong.
+ */
+
+export {};

--- a/frontend/tsconfig.build.json
+++ b/frontend/tsconfig.build.json
@@ -1,0 +1,22 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist",
+    "emitDeclarationOnly": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "dist",
+    "node_modules",
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.test.js",
+    "**/*.test.jsx",
+    "**/setupTest.ts",
+    "**/setupTest.js"
+  ]
+}


### PR DESCRIPTION
This PR moves the build process to use tsc and babel. It should fix the current build error where we see:

```

#48 [authoring-prod 1/1] RUN npm run build
#48 174.0 Webpack Bundle Analyzer saved report to /openedx/app/dist/report.html
#48 174.5 assets by path *.js 12.5 MiB
#48 174.5   assets by status 12.4 MiB [big] 3 assets
#48 174.5   + 11 assets
#48 174.5 assets by chunk 84.5 KiB (auxiliary name: app)
#48 174.5   assets by path *.png 20 KiB 6 assets
#48 174.5   assets by path *.svg 64.5 KiB
#48 174.5     asset 54c2ffb7717f21032023b707a1599e50.svg 36 KiB [emitted] [immutable] [from: src/search-modal/images/empty-search.svg] (auxiliary name: app)
#48 174.5     + 2 assets
#48 174.5 assets by path *.css 850 KiB
#48 174.5   asset app.3c4b213d33d47a6fc42c.css 576 KiB [emitted] [immutable] [big] (name: app) 1 related asset
#48 174.5   asset 178.6b80901b4e6a9af519ac.css 171 KiB [emitted] [immutable] (id hint: vendors) 1 related asset
#48 174.5   asset 281.a5c0beb30669a0069970.css 103 KiB [emitted] [immutable] (id hint: vendors) 1 related asset
#48 174.5 asset index.html 860 bytes [emitted]
#48 174.5 asset 95ec738c0b7faac5b5c9126794446bbd.svg 342 bytes [emitted] [immutable] [from: node_modules/@openedx/paragon/dist/Avatar/default-avatar.svg] (auxiliary id hint: vendors)
#48 174.5 Entrypoint app [big] 12.4 MiB (23.8 MiB) = runtime.37c6c7bafabb352166d1.js 4.89 KiB 281.a5c0beb30669a0069970.css 103 KiB 281.a5c0beb30669a0069970.js 5.02 MiB app.3c4b213d33d47a6fc42c.css 576 KiB app.3c4b213d33d47a6fc42c.js 6.74 MiB 15 auxiliary assets
#48 174.5 orphan modules 15.9 MiB [orphan] 4653 modules
#48 174.5 runtime modules 11.6 KiB 17 modules
#48 174.5 built modules 20.9 MiB (javascript) 850 KiB (css/mini-extract) [built]
#48 174.5   modules by path ./node_modules/ 12.9 MiB (javascript) 274 KiB (css/mini-extract)
#48 174.5     javascript modules 12.9 MiB 1161 modules
#48 174.5     css modules 274 KiB 5 modules
#48 174.5     json modules 14.7 KiB
#48 174.5       ./node_modules/i18n-iso-countries/codes.json 8.55 KiB [built] [code generated]
#48 174.5       ./node_modules/@cospired/i18n-iso-languages/codes.json 6.12 KiB [built] [code generated]
#48 174.5   modules by path ./src/ 7.95 MiB (javascript) 576 KiB (css/mini-extract)
#48 174.5     javascript modules 7.95 MiB 26 modules
#48 174.5     css modules 576 KiB 19 modules
#48 174.5   ./env.config.jsx 2.42 KiB [built] [code generated]
#48 174.5 
#48 174.5 WARNING in ./env.config.jsx 29:16-59
#48 174.5 Module not found: Error: Can't resolve '@openedx/openedx-ai-extensions-ui' in '/openedx/app'
#48 174.5  @ ./node_modules/@edx/frontend-platform/initialize.js 437:0-35 570:23-32 575:17-26 581:19-28
#48 174.5  @ ./node_modules/@edx/frontend-platform/index.js
#48 174.5  @ ./src/index.jsx
#48 174.5 
#48 174.5 WARNING in asset size limit: The following asset(s) exceed the recommended size limit (244 KiB).
#48 174.5 This can impact web performance.
#48 174.5 Assets: 
#48 174.5   app.3c4b213d33d47a6fc42c.css (576 KiB)
#48 174.5   app.3c4b213d33d47a6fc42c.js (6.74 MiB)
#48 174.5   281.a5c0beb30669a0069970.js (5.02 MiB)
#48 174.5   716.ca94b6be711b93d81908.js (609 KiB)
```