### PR TITLE
fix: update package.json to add style files in the bundle

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
   "files": [
     "dist/"
   ],
-  "sideEffects": false,
+  "sideEffects": ["**/*.scss", "**/*.css"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openedx/openedx-ai-extensions.git"


### PR DESCRIPTION
The `package.json` is configured with `sideEffects=true`, which enables tree shaking. As a result, only JavaScript code is loaded while style imports may be discarded during the build process.

For better understanding, see the webpack documentation: [Full Example: Understanding Side Effects with CSS Files](https://webpack.js.org/guides/tree-shaking/#full-example-understanding-side-effects-with-css-files)

In our case, we are working with `scss` files, so they need to be included in the sideEffects configuration to ensure they are not removed during tree shaking.  From a bundle perspective, it is safe to expose `scss` files directly, as they are correctly handled and compiled through the webpack configuration provided by [ frontend-build](https://github.com/eduNEXT/frontend-build/blob/e3856b0fab23dd271e6f018103f94bae36080421/config/webpack.prod.config.js#L127C1-L141C13)