### PR TITLE
chore: Relax dependencies to support Open edX Ulmo 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=20.0.0,<21.0.0",
-    "tutor-mfe>=20.0.0,<21.0.0",
+    "tutor>=20.0.0,<22.0.0",
+    "tutor-mfe>=20.0.0,<22.0.0",
 ]
 
 # these fields will be set by .hatch_build.py
@@ -33,7 +33,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "tutor[dev]>=20.0.0,<21.0.0",
+    "tutor[dev]>=20.0.0,<22.0.0",
     "pylint",
 ]
 


### PR DESCRIPTION
I have recently begun testing this extension, but our reference dev environment is already on Ulmo. Thus, I ran from my own fork with this patch applied, and things appear to be working fine:

Update `pyproject.toml` to support version 21 for the `tutor` and `tutor-mfe` dependencies.
