### PR TITLE
feat: add backend for flashcards

### DIFF
--- a/backend/openedx_ai_extensions/processors/llm/educator_assistant_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/educator_assistant_processor.py
@@ -86,7 +86,6 @@ class EducatorAssistantProcessor(LitellmProcessor):
         for key, value in input_data.items():
             placeholder = f"{{{{{key.upper()}}}}}"
             prompt = prompt.replace(placeholder, str(value))
-        logger.info(f"Generation prompt after placeholder replacement: {prompt}")
 
         try:
             result = self._call_completion_api(prompt)

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -677,6 +677,9 @@ class LLMProcessor(LitellmProcessor):
             logger.exception(f"Error calling LiteLLM: {e}")
             return {"error": f"AI processing failed: {str(e)}"}
 
+        if "error" in result:
+            return result
+
         tokens_used = result.get("tokens_used", 0)
         response = json.loads(result['response'])
 

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -5,6 +5,7 @@ Responses processor for threaded AI conversations using LiteLLM
 import json
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
 from litellm import completion, get_responses, list_input_items, responses
 
@@ -649,3 +650,39 @@ class LLMProcessor(LitellmProcessor):
                 if summary_text:
                     items.append({"type": "reasoning", "role": "reasoning", "content": summary_text})
         return items
+
+    def generate_flashcards(self):
+        """Example method showing how to generate flashcards from content."""
+        prompt_file_path = (
+            Path(__file__).resolve().parent.parent.parent
+            / "prompts"
+            / "default_generate_flashcards.txt"
+        )
+        try:
+            with open(prompt_file_path, "r") as f:
+                prompt = f.read()
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.exception(f"Error loading prompt template: {e}")
+            return {"error": "Failed to load prompt template."}
+
+        for key, value in self.input_data.items():
+            placeholder = f"{{{{{key.upper()}}}}}"
+            prompt = prompt.replace(placeholder, str(value))
+
+        self.input_data = None
+
+        try:
+            result = self._call_completion_wrapper(prompt)
+        except Exception as e:  # pylint: disable=broad-exception-caught
+            logger.exception(f"Error calling LiteLLM: {e}")
+            return {"error": f"AI processing failed: {str(e)}"}
+
+        tokens_used = result.get("tokens_used", 0)
+        response = json.loads(result['response'])
+
+        return {
+            "response": response,
+            "tokens_used": tokens_used,
+            "model_used": self.extra_params.get("model", "unknown"),
+            "status": "success",
+        }

--- a/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
+++ b/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
@@ -1,0 +1,45 @@
+- Role & Purpose
+
+    You are an AI assistant embedded into an Open edX learning environment. Your purpose is to assist learners and course authors by generating high-quality flashcards for spaced-repetition study, based strictly on the provided course unit content.
+
+- Core Behaviors
+
+    Always derive flashcard content exclusively from the course context provided below.
+    Do not introduce external facts, definitions, or concepts that are not present in the source material.
+    Maintain clarity, accuracy, and educational value in every card.
+    Each flashcard must target a single, distinct concept or fact — avoid compound questions.
+    Write questions that actively test recall, not recognition. Prefer "What is...?", "How does...work?", "Why does...?" over yes/no formats.
+    Answers must be concise but complete — enough to stand alone without re-reading the question.
+    Avoid hallucinating facts or paraphrasing in a way that changes meaning.
+
+- Flashcard Generation Rules
+
+    Generate exactly {{NUM_CARDS}} flashcards from the course content.
+    Cover a diverse range of concepts from the material — do not repeat the same idea across multiple cards.
+    Each card must have a unique `id` in the format "card-1", "card-2", etc.
+
+- Question Writing Guidelines
+
+    Good question patterns:
+      - "What is the definition of [concept]?"
+      - "What are the [N] steps/phases of [process]?"
+      - "How does [mechanism] achieve [outcome]?"
+      - "What distinguishes [X] from [Y]?"
+      - "Why is [principle] important in the context of [topic]?"
+      - "What happens when [condition] in [system]?"
+
+    Avoid:
+      - Trick questions or pedantic edge cases not covered in the material.
+      - Questions whose answers require multi-paragraph explanations.
+      - Questions that give away the answer in the phrasing (e.g., "The process that does X is called?").
+
+- Answer Writing Guidelines
+
+    Keep answers between one sentence and three short sentences.
+    Use precise terminology from the course material.
+    If the answer is a list, use a comma-separated format or a short numbered list (2–5 items max).
+    Do not prefix answers with "The answer is" or similar redundant phrasing.
+
+- Course Content
+
+  The following is the source course unit content. Generate all flashcards strictly from this material.

--- a/backend/openedx_ai_extensions/response_schemas/flashcards.json
+++ b/backend/openedx_ai_extensions/response_schemas/flashcards.json
@@ -1,0 +1,41 @@
+{
+  "type": "json_schema",
+  "json_schema": {
+    "name": "FlashcardGeneration",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "cards": {
+          "type": "array",
+          "description": "The list of flashcards generated from the course content.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "A unique identifier for the flashcard (e.g., 'card-1', 'card-2'). Must be unique within the set."
+              },
+              "question": {
+                "type": "string",
+                "description": "The front of the flashcard. A clear, concise question or prompt derived from the course content."
+              },
+              "answer": {
+                "type": "string",
+                "description": "The back of the flashcard. The correct and complete answer to the question. Can include brief explanations."
+              }
+            },
+            "required": [
+              "id",
+              "question",
+              "answer"
+            ],
+            "additionalProperties": false
+          }
+        }
+      },
+      "required": ["cards"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
@@ -1,0 +1,130 @@
+"""
+Orchestrators for handling different AI workflow patterns in Open edX.
+"""
+import json
+import random
+from pathlib import Path
+
+from openedx_ai_extensions.processors import LLMProcessor, OpenEdXProcessor
+from openedx_ai_extensions.xapi.constants import EVENT_NAME_WORKFLOW_COMPLETED
+
+from .session_based_orchestrator import SessionBasedOrchestrator
+
+
+class FlashCardsOrchestrator(SessionBasedOrchestrator):
+    """
+    Orchestrator for flashcards generation using LLM.
+    Does a single call to an LLM and gives a response.
+    """
+
+    @property
+    def _schema_path(self):
+        return (
+            Path(__file__).resolve().parent.parent.parent
+            / "response_schemas"
+            / "flashcards.json"
+        )
+
+    def run(self, input_data):
+        """
+        Executes the content fetching, LLM processing, and handles streaming
+        or structured response return.
+        """
+
+        # --- 1. Process with OpenEdX processor (Content Fetching) ---
+        openedx_processor = OpenEdXProcessor(
+            processor_config=self.profile.processor_config,
+            location_id=self.location_id,
+            course_id=self.course_id,
+            user=self.user,
+        )
+        content_result = openedx_processor.process()
+
+        # Early return on error during content fetching
+        if content_result and 'error' in content_result:
+            return {
+                'error': content_result['error'],
+                'status': 'OpenEdXProcessor error'
+            }
+
+        # Convert fetched content to a string format suitable for the LLM
+        llm_input_content = str(content_result)
+
+        if input_data.get('num_cards', None) is None:
+            # Generate random number of cards between 1 and 25 if num_cards is not provided or is None
+            input_data['num_cards'] = random.randint(1, 25)
+        with open(self._schema_path, 'r', encoding='utf-8') as f:
+            llm_processor = LLMProcessor(
+                config=self.profile.processor_config,
+                extra_params={"response_format": json.load(f)}
+            )
+        llm_result = llm_processor.process(
+            context=llm_input_content,
+            input_data=input_data,
+        )
+
+        if llm_result and 'error' in llm_result:
+            return {
+                'error': llm_result['error'],
+                'status': 'LLMProcessor error'
+            }
+
+        self._emit_workflow_event(EVENT_NAME_WORKFLOW_COMPLETED)
+
+        response_obj = llm_result.get('response')
+        cards = []
+        if isinstance(response_obj, dict):
+            potential_cards = response_obj.get('cards')
+            if isinstance(potential_cards, list):
+                cards = potential_cards
+        elif isinstance(response_obj, list):
+            cards = response_obj
+
+        if cards is not None:
+            for card in cards:
+                if isinstance(card, dict):
+                    card['nextReviewTime'] = 0
+                    card['interval'] = 1
+                    card['easeFactor'] = 2.5
+                    card['repetitions'] = 0
+                    card['lastReviewedAt'] = None
+
+        if isinstance(response_obj, dict):
+            enriched_response = dict(response_obj)
+            enriched_response['cards'] = cards
+        else:
+            enriched_response = cards
+
+        response_data = {
+            'response': enriched_response,
+            'status': 'completed',
+            'metadata': {
+                'tokens_used': llm_result.get('tokens_used'),
+                'model_used': llm_result.get('model_used')
+            }
+        }
+        return response_data
+
+    def save(self, input_data):
+        """
+        Saves the generated flashcards to the database or a file.
+        This is a placeholder implementation and should be replaced with actual saving logic.
+        """
+        # Placeholder: Implement actual saving logic here (e.g., save to DB or file)
+        self.session.metadata['cards'] = input_data.get('card_stack')
+        self.session.save(update_fields=['metadata'])
+        return {
+            'status': 'flashcards_saved',
+        }
+
+    def get_current_session_response(self, _):
+        """
+        Retrieve the current session state.
+
+        - If flashcards were generated but not yet saved: return them for review.
+        - Otherwise: return None.
+        """
+        metadata = self.session.metadata or {}
+        if "cards" in metadata:
+            return metadata["cards"]
+        return None

--- a/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
@@ -14,6 +14,7 @@ from .session_based_orchestrator import SessionBasedOrchestrator
 class FlashCardsOrchestrator(SessionBasedOrchestrator):
     """
     Orchestrator for flashcards generation using LLM.
+
     Does a single call to an LLM and gives a response.
     """
 
@@ -110,8 +111,7 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         Saves the generated flashcards to the database or a file.
         This is a placeholder implementation and should be replaced with actual saving logic.
         """
-        # Placeholder: Implement actual saving logic here (e.g., save to DB or file)
-        self.session.metadata['cards'] = input_data.get('card_stack')
+        self.session.metadata['cards'] = input_data.get('cards') or input_data.get('card_stack')
         self.session.save(update_fields=['metadata'])
         return {
             'status': 'flashcards_saved',

--- a/backend/openedx_ai_extensions/workflows/profiles/experimental/fashcards.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/experimental/fashcards.json
@@ -1,0 +1,37 @@
+/*
+Use an AI workflow to create multiple answer questions in a library
+starting from the current course content unit
+Works only in studio UI and over the CMS service_variant.
+*/
+{
+  "orchestrator_class": "openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.FlashCardsOrchestrator",
+  "processor_config": {
+    "OpenEdXProcessor": {
+      "function": "get_location_content"
+    },
+    "LLMProcessor": {
+      "function": "generate_flashcards",
+      "provider": "openai",
+      "cache": true
+    }
+  },
+  "actuator_config": {
+    "UIComponents": {
+      "request": {
+        "component": "FlashcardCreator",
+        "config": {
+          "buttonText": "Start",
+          "customMessage": "",
+          "preloadPreviousSession": true
+        }
+      },
+      "response": {
+        "component": "FlashcardStudyResponse",
+        "config": {
+          "customMessage": "Assistance completed successfully",
+        }
+      }
+    }
+  },
+  "schema_version": "1.0",
+}

--- a/backend/openedx_ai_extensions/workflows/profiles/experimental/fashcards.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/experimental/fashcards.json
@@ -1,7 +1,7 @@
 /*
-Use an AI workflow to create multiple answer questions in a library
-starting from the current course content unit
-Works only in studio UI and over the CMS service_variant.
+Use an AI workflow to generate and study flashcards
+starting from the current course content unit.
+Works only in Studio UI and over the CMS service_variant.
 */
 {
   "orchestrator_class": "openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.FlashCardsOrchestrator",

--- a/backend/tests/test_flashcards_orchestrator.py
+++ b/backend/tests/test_flashcards_orchestrator.py
@@ -1,0 +1,740 @@
+"""
+Tests for flashcards_orchestrator.
+"""
+# pylint: disable=protected-access
+
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+from opaque_keys.edx.keys import CourseKey
+
+from openedx_ai_extensions.workflows.models import AIWorkflowProfile, AIWorkflowScope
+from openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator import FlashCardsOrchestrator
+
+User = get_user_model()
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def user(db):  # pylint: disable=unused-argument
+    return User.objects.create_user(
+        username="flashcards_test_user",
+        email="flashcards@example.com",
+        password="password123",
+    )
+
+
+@pytest.fixture
+def course_key():
+    return CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+
+
+@pytest.fixture
+def workflow_profile(db):  # pylint: disable=unused-argument
+    return AIWorkflowProfile.objects.create(
+        slug="test-flashcards",
+        description="Flashcards profile for tests",
+        base_filepath="experimental/fashcards.json",
+        content_patch="{}",
+    )
+
+
+@pytest.fixture
+def workflow_scope(workflow_profile, course_key):  # pylint: disable=redefined-outer-name
+    return AIWorkflowScope.objects.create(
+        location_regex=".*test_unit.*",
+        course_id=course_key,
+        service_variant="cms",
+        profile=workflow_profile,
+        enabled=True,
+    )
+
+
+@pytest.fixture
+def flashcards_orchestrator(workflow_scope, user, course_key):  # pylint: disable=redefined-outer-name
+    """Instantiate FlashCardsOrchestrator with a real DB session."""
+    context = {
+        "course_id": str(course_key),
+        "location_id": None,
+    }
+    return FlashCardsOrchestrator(
+        workflow=workflow_scope,
+        user=user,
+        context=context,
+    )
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.get_current_session_response
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_get_current_session_response_with_cards(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When session metadata contains cards, get_current_session_response returns them.
+    """
+    cards = [
+        {"id": "card-1", "question": "What is 2+2?", "answer": "4"},
+        {"id": "card-2", "question": "Capital of France?", "answer": "Paris"},
+    ]
+    flashcards_orchestrator.session.metadata = {"cards": cards}
+
+    result = flashcards_orchestrator.get_current_session_response(None)
+    assert result == cards
+
+
+@pytest.mark.django_db
+def test_get_current_session_response_no_cards(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When there are no cards in metadata, returns None.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    result = flashcards_orchestrator.get_current_session_response(None)
+    assert result is None
+
+
+@pytest.mark.django_db
+def test_get_current_session_response_none_metadata(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When session metadata is None, returns None.
+    """
+    flashcards_orchestrator.session.metadata = None
+
+    result = flashcards_orchestrator.get_current_session_response(None)
+    assert result is None
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — OpenEdXProcessor error
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+def test_run_openedx_error(
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When OpenEdXProcessor.process returns an error dict, run() propagates it.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"error": "Course unit not found"}
+    mock_openedx_class.return_value = mock_openedx
+
+    result = flashcards_orchestrator.run({"num_cards": 5})
+
+    assert "error" in result
+    assert result["error"] == "Course unit not found"
+    assert result["status"] == "OpenEdXProcessor error"
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — LLMProcessor error
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_llm_error(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When LLMProcessor.process returns an error, run() returns an LLM error.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "Some course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {"error": "AI API failed"}
+    mock_llm_class.return_value = mock_llm
+
+    result = flashcards_orchestrator.run({"num_cards": 5})
+
+    assert "error" in result
+    assert result["error"] == "AI API failed"
+    assert result["status"] == "LLMProcessor error"
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — success path with dict response
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_success_dict_response(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    Full success path: response is a dict with 'cards' list.
+    Cards should be enriched with spaced-repetition fields.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    cards = [
+        {"id": "card-1", "question": "What is 2+2?", "answer": "4"},
+        {"id": "card-2", "question": "Capital of France?", "answer": "Paris"},
+    ]
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": cards},
+        "tokens_used": 200,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 2})
+
+    assert result["status"] == "completed"
+    assert result["metadata"]["tokens_used"] == 200
+    assert result["metadata"]["model_used"] == "openai/gpt-4"
+
+    enriched_cards = result["response"]["cards"]
+    assert len(enriched_cards) == 2
+    for card in enriched_cards:
+        assert card["nextReviewTime"] == 0
+        assert card["interval"] == 1
+        assert card["easeFactor"] == 2.5
+        assert card["repetitions"] == 0
+        assert card["lastReviewedAt"] is None
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_success_emits_workflow_event(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    On success, run() emits a workflow completed event.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event") as mock_emit:
+        flashcards_orchestrator.run({"num_cards": 1})
+
+    mock_emit.assert_called_once()
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — success path with list response
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_success_list_response(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When response_obj is a list (not a dict), cards are extracted directly.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    cards = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+    ]
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": cards,
+        "tokens_used": 50,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 1})
+
+    assert result["status"] == "completed"
+    # When response is a list, enriched_response is the cards list directly
+    enriched_cards = result["response"]
+    assert isinstance(enriched_cards, list)
+    assert len(enriched_cards) == 1
+    assert enriched_cards[0]["nextReviewTime"] == 0
+    assert enriched_cards[0]["easeFactor"] == 2.5
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — default num_cards
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.random")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_default_num_cards(
+    mock_llm_class,
+    mock_openedx_class,
+    mock_random,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When num_cards is not provided, a random number between 1 and 25 is generated.
+    """
+    mock_random.randint.return_value = 10
+
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        flashcards_orchestrator.run({})
+
+    mock_random.randint.assert_called_once_with(1, 25)
+    # Verify input_data was updated with the random num_cards
+    call_kwargs = mock_llm.process.call_args[1]
+    assert call_kwargs["input_data"]["num_cards"] == 10
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_explicit_num_cards_not_overridden(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When num_cards is explicitly provided, the random fallback is not used.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        flashcards_orchestrator.run({"num_cards": 7})
+
+    call_kwargs = mock_llm.process.call_args[1]
+    assert call_kwargs["input_data"]["num_cards"] == 7
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — schema file is loaded
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_loads_schema_and_passes_response_format(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    run() loads the flashcards JSON schema and passes it as response_format to LLMProcessor.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    schema_data = {"type": "json_schema", "json_schema": {"name": "FlashcardGeneration"}}
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"), \
+         patch("builtins.open", mock_open(read_data='{"type": "json_schema"}')), \
+         patch("json.load", return_value=schema_data):
+        flashcards_orchestrator.run({"num_cards": 3})
+
+    # Verify LLMProcessor was instantiated with the response_format
+    call_kwargs = mock_llm_class.call_args[1]
+    assert "response_format" in call_kwargs["extra_params"]
+    assert call_kwargs["extra_params"]["response_format"] == schema_data
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — empty cards list
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_success_empty_cards(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When LLM returns an empty cards list, run() still completes successfully.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 5,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 0})
+
+    assert result["status"] == "completed"
+    assert result["response"]["cards"] == []
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — response with no 'cards' key
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_dict_response_no_cards_key(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When response is a dict but has no 'cards' key, enriched_response should
+    still be a dict with an empty cards list.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"other_data": "value"},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 1})
+
+    assert result["status"] == "completed"
+    assert result["response"]["cards"] == []
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — response_obj is None
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_none_response(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When response_obj is None, cards defaults to empty list.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": None,
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 1})
+
+    assert result["status"] == "completed"
+    # None is neither dict nor list, so enriched_response = cards = []
+    assert result["response"] == []
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.save
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_save_stores_cards_in_session(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    save() stores cards in session metadata and returns flashcards_saved status.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    cards = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+        {"id": "card-2", "question": "Q2?", "answer": "A2"},
+    ]
+    result = flashcards_orchestrator.save({"cards": cards})
+
+    assert result["status"] == "flashcards_saved"
+
+    flashcards_orchestrator.session.refresh_from_db()
+    assert flashcards_orchestrator.session.metadata["cards"] == cards
+
+
+@pytest.mark.django_db
+def test_save_stores_card_stack_fallback(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    save() falls back to 'card_stack' key when 'cards' is not present.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    card_stack = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+    ]
+    result = flashcards_orchestrator.save({"card_stack": card_stack})
+
+    assert result["status"] == "flashcards_saved"
+
+    flashcards_orchestrator.session.refresh_from_db()
+    assert flashcards_orchestrator.session.metadata["cards"] == card_stack
+
+
+@pytest.mark.django_db
+def test_save_prefers_cards_over_card_stack(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    save() prefers 'cards' key over 'card_stack' when both are present.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    cards = [{"id": "card-1", "question": "Q?", "answer": "A"}]
+    card_stack = [{"id": "card-2", "question": "Q2?", "answer": "A2"}]
+    result = flashcards_orchestrator.save({"cards": cards, "card_stack": card_stack})
+
+    assert result["status"] == "flashcards_saved"
+
+    flashcards_orchestrator.session.refresh_from_db()
+    assert flashcards_orchestrator.session.metadata["cards"] == cards
+
+
+@pytest.mark.django_db
+def test_save_with_no_cards_or_card_stack(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    save() stores None when neither 'cards' nor 'card_stack' are present.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    result = flashcards_orchestrator.save({})
+
+    assert result["status"] == "flashcards_saved"
+
+    flashcards_orchestrator.session.refresh_from_db()
+    assert flashcards_orchestrator.session.metadata["cards"] is None
+
+
+# ===========================================================================
+# FlashCardsOrchestrator._schema_path
+# ===========================================================================
+
+
+def test_schema_path_points_to_flashcards_json(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    _schema_path should point to the flashcards.json schema file.
+    """
+    schema_path = flashcards_orchestrator._schema_path
+    assert schema_path.name == "flashcards.json"
+    assert "response_schemas" in str(schema_path)
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — card enrichment details
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_card_enrichment_preserves_original_fields(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    Card enrichment adds spaced-repetition fields without removing original fields.
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    cards = [
+        {"id": "card-1", "question": "What is DNA?", "answer": "Deoxyribonucleic acid"},
+    ]
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": cards},
+        "tokens_used": 100,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 1})
+
+    card = result["response"]["cards"][0]
+    # Original fields preserved
+    assert card["id"] == "card-1"
+    assert card["question"] == "What is DNA?"
+    assert card["answer"] == "Deoxyribonucleic acid"
+    # Spaced-repetition fields added
+    assert card["nextReviewTime"] == 0
+    assert card["interval"] == 1
+    assert card["easeFactor"] == 2.5
+    assert card["repetitions"] == 0
+    assert card["lastReviewedAt"] is None
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — non-dict items in cards list are skipped
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_non_dict_card_items_are_skipped(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    Non-dict items in the cards list are not enriched (no error raised).
+    """
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    cards = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+        "not-a-dict",
+        42,
+    ]
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": cards},
+        "tokens_used": 50,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        result = flashcards_orchestrator.run({"num_cards": 1})
+
+    assert result["status"] == "completed"
+    enriched_cards = result["response"]["cards"]
+    # Only the dict item gets enriched
+    assert "nextReviewTime" in enriched_cards[0]
+    assert enriched_cards[1] == "not-a-dict"
+    assert enriched_cards[2] == 42
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — LLMProcessor receives correct arguments
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_passes_content_and_input_data_to_llm(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    run() passes the stringified content result and input_data to LLMProcessor.process().
+    """
+    content_data = {"content": "Python fundamentals: variables, functions, and loops"}
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = content_data
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": []},
+        "tokens_used": 10,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    input_data = {"num_cards": 5}
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        flashcards_orchestrator.run(input_data)
+
+    call_kwargs = mock_llm.process.call_args[1]
+    assert call_kwargs["context"] == str(content_data)
+    assert call_kwargs["input_data"] == input_data

--- a/backend/tests/test_llm_processor.py
+++ b/backend/tests/test_llm_processor.py
@@ -2,9 +2,10 @@
 Tests for the LLMProcessor module.
 """
 # pylint: disable=redefined-outer-name,protected-access
+import json
 import types
 import unittest
-from unittest.mock import Mock, patch
+from unittest.mock import Mock, mock_open, patch
 
 import pytest
 from django.contrib.auth import get_user_model
@@ -1417,3 +1418,206 @@ def test_yield_threaded_stream_recursive_tool_call(
         assert history[1]["name"] == "roll_dice"
 
         mock_responses.assert_called_once()
+
+
+# ============================================================================
+# generate_flashcards Tests
+# ============================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_generate_flashcards_success(
+    mock_completion, user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that generate_flashcards loads the prompt template, replaces
+    placeholders, calls LLM, and returns parsed JSON response.
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "openai/gpt-3.5-turbo",
+            "API_KEY": "test-key"
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "generate_flashcards",
+            "model": "gpt-3.5-turbo",
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+
+    flashcards_json = json.dumps({
+        "cards": [
+            {"id": "card-1", "question": "What is Python?", "answer": "A programming language."}
+        ]
+    })
+    mock_resp_obj = MockChunk(flashcards_json, is_stream=False)
+    mock_completion.return_value = mock_resp_obj
+
+    prompt_template = "Generate {{NUM_CARDS}} flashcards about {{TOPIC}}."
+    with patch("builtins.open", mock_open(read_data=prompt_template)):
+        result = processor.process(
+            input_data={"num_cards": "5", "topic": "Python"},
+        )
+
+    assert result["status"] == "success"
+    assert isinstance(result["response"], dict)
+    assert len(result["response"]["cards"]) == 1
+    assert result["response"]["cards"][0]["question"] == "What is Python?"
+
+    # Verify placeholder replacement was applied to the prompt
+    call_kwargs = mock_completion.call_args[1]
+    messages = call_kwargs["messages"]
+    system_msg = messages[0]["content"]
+    assert "5" in system_msg
+    assert "Python" in system_msg
+    assert "{{NUM_CARDS}}" not in system_msg
+    assert "{{TOPIC}}" not in system_msg
+
+
+@pytest.mark.django_db
+def test_generate_flashcards_prompt_file_error(
+    user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that generate_flashcards returns an error when the prompt file cannot be loaded.
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "openai/gpt-3.5-turbo",
+            "API_KEY": "test-key"
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "generate_flashcards",
+            "model": "gpt-3.5-turbo",
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+
+    with patch("builtins.open", side_effect=FileNotFoundError("prompt file not found")):
+        result = processor.process(
+            input_data={"num_cards": "5"},
+        )
+
+    assert "error" in result
+    assert result["error"] == "Failed to load prompt template."
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_generate_flashcards_llm_api_error(
+    mock_completion, user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that generate_flashcards returns an error when the LLM API call fails.
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "openai/gpt-3.5-turbo",
+            "API_KEY": "test-key"
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "generate_flashcards",
+            "model": "gpt-3.5-turbo",
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+
+    mock_completion.side_effect = Exception("API connection refused")
+
+    prompt_template = "Generate {{NUM_CARDS}} flashcards."
+    with patch("builtins.open", mock_open(read_data=prompt_template)):
+        result = processor.process(
+            input_data={"num_cards": "3"},
+        )
+
+    assert "error" in result
+    assert "API connection refused" in result["error"]
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_generate_flashcards_clears_input_data(
+    mock_completion, user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that generate_flashcards clears self.input_data before calling the LLM
+    (so it's not passed as a user message by _call_completion_wrapper).
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "openai/gpt-3.5-turbo",
+            "API_KEY": "test-key"
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "generate_flashcards",
+            "model": "gpt-3.5-turbo",
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+
+    flashcards_json = json.dumps({"cards": []})
+    mock_resp_obj = MockChunk(flashcards_json, is_stream=False)
+    mock_completion.return_value = mock_resp_obj
+
+    prompt_template = "Generate {{NUM_CARDS}} flashcards."
+    with patch("builtins.open", mock_open(read_data=prompt_template)):
+        processor.process(input_data={"num_cards": "3"})
+
+    # input_data should have been cleared before calling _call_completion_wrapper
+    assert processor.input_data is None
+
+    # Verify no user message was added (only system message + possibly context)
+    call_kwargs = mock_completion.call_args[1]
+    messages = call_kwargs["messages"]
+    user_messages = [m for m in messages if m.get("role") == "user"]
+    assert len(user_messages) == 0
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.processors.llm.llm_processor.completion")
+def test_generate_flashcards_returns_tokens_and_model(
+    mock_completion, user_session, settings  # pylint: disable=redefined-outer-name
+):
+    """
+    Test that generate_flashcards returns tokens_used and model_used in the result.
+    """
+    settings.AI_EXTENSIONS = {
+        "default": {
+            "MODEL": "openai/gpt-3.5-turbo",
+            "API_KEY": "test-key"
+        }
+    }
+
+    config = {
+        "LLMProcessor": {
+            "function": "generate_flashcards",
+            "model": "gpt-4o",
+        }
+    }
+    processor = LLMProcessor(config=config, user_session=user_session)
+
+    flashcards_json = json.dumps({"cards": [{"id": "card-1", "question": "Q?", "answer": "A"}]})
+    mock_resp = MockChunk(flashcards_json, is_stream=False)
+    mock_resp.usage = Mock(total_tokens=150)
+    mock_completion.return_value = mock_resp
+
+    prompt_template = "Generate flashcards."
+    with patch("builtins.open", mock_open(read_data=prompt_template)):
+        result = processor.process(input_data={})
+
+    assert result["tokens_used"] == 150
+    # model_used comes from extra_params which resolves from AI_EXTENSIONS settings
+    assert result["model_used"] == "openai/gpt-3.5-turbo"


### PR DESCRIPTION
This pull request introduces a new flashcard generation workflow for Open edX, enabling AI-powered creation of high-quality flashcards from course content. The main changes include the addition of a dedicated orchestrator, a prompt template, a response schema, and integration into the workflow profiles. The implementation ensures flashcards are generated according to strict educational guidelines and returned in a structured format.

Flashcard Generation Workflow

* Added `FlashCardsOrchestrator` for managing flashcard generation, including content fetching, LLM processing, enriching flashcards with spaced-repetition metadata, and session management. (`backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py`)
* Integrated the workflow into the experimental profile with configuration for orchestrator, processors, and UI components. (`backend/openedx_ai_extensions/workflows/profiles/experimental/fashcards.json`)

Prompt and Schema Enhancements

* Introduced a detailed prompt template specifying flashcard generation rules, question/answer guidelines, and behavioral constraints for the AI. (`backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt`)
* Added a JSON schema for flashcard responses, enforcing structure and uniqueness for each card. (`backend/openedx_ai_extensions/response_schemas/flashcards.json`)

Processor Updates

* Implemented `generate_flashcards` method in `LLMProcessor`, handling prompt loading, placeholder replacement, and LLM API calls for flashcard generation. (`backend/openedx_ai_extensions/processors/llm/llm_processor.py`)
* Minor code cleanup: removed a verbose log statement from the educator assistant processor and imported `Path` for prompt handling. (`backend/openedx_ai_extensions/processors/llm/educator_assistant_processor.py`, `backend/openedx_ai_extensions/processors/llm/llm_processor.py`) [[1]](diffhunk://#diff-0279ca4ec9bed9d7815e67c5ac20d3bb9396455482de7bdb35350e8502e02434L89) [[2]](diffhunk://#diff-4c0b642c599c21650ab75f40a6b8ab27cb0eb2ae2a927e0c85bb63c4ced72a9eR8)