### PR TITLE
fix: use prepareContextData in FlashCardFResponse

### DIFF
--- a/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
@@ -12,6 +12,7 @@ import { useStudySession } from '../hooks/useStudySession';
 import { calculateNextReview } from '../utils';
 import { saveCardStack, clearSession } from '../data/workflowActions';
 import { Flashcard as FlashcardType, CardStack } from '../types';
+import { prepareContextData } from '../../services';
 import LastReviewLabel from './LastReviewLabel';
 import messages from '../messages';
 
@@ -41,6 +42,7 @@ const FlashcardStudyResponse = ({
   contextData = {},
 }: FlashcardStudyResponseProps) => {
   const intl = useIntl();
+  const preparedContext = useMemo(() => prepareContextData(contextData), [contextData]);
   const [cards, setCards] = useState<FlashcardType[]>(() => parseCards(response));
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFlipped, setIsFlipped] = useState(false);
@@ -74,11 +76,11 @@ const FlashcardStudyResponse = ({
         createdAt: Date.now(),
         lastStudiedAt: Date.now(),
       };
-      await saveCardStack({ context: contextData, cardStack });
+      await saveCardStack({ context: preparedContext, cardStack });
     } catch {
       setSaveError(intl.formatMessage(messages['ai.extensions.flashcard.error.save']));
     }
-  }, [contextData, intl]);
+  }, [preparedContext, intl]);
 
   // Auto-save when the tab becomes hidden (covers tab switches, screen locks, alt-tabs)
   useEffect(() => {
@@ -130,7 +132,7 @@ const FlashcardStudyResponse = ({
 
   const handleClearSession = async () => {
     try {
-      await clearSession({ context: contextData });
+      await clearSession({ context: preparedContext });
     } catch {
       // Silently fail — still reset the UI
     }


### PR DESCRIPTION
This pull request refactors how context data is handled in the `FlashcardStudyResponse` component to ensure it is consistently prepared before being used in workflow actions. The main change is the introduction of the `prepareContextData` utility, which processes the context data before it is passed to actions like saving card stacks or clearing sessions.

Context preparation improvements:

* Added import of `prepareContextData` from `../../services` and used `useMemo` to create a prepared context (`preparedContext`) from `contextData`. This ensures context data is processed once and reused throughout the component. [[1]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322R15) [[2]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322R45)
* Updated calls to `saveCardStack` and `clearSession` to use `preparedContext` instead of raw `contextData`, ensuring workflow actions receive consistently formatted context. [[1]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322L77-R83) [[2]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322L133-R135)