### PR TITLE
feat: improve flashcards

### DIFF
--- a/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
+++ b/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
@@ -18,6 +18,9 @@
     Cover a diverse range of concepts from the material — do not repeat the same idea across multiple cards.
     Each card must have a unique `id` in the format "card-1", "card-2", etc.
 
+    Here are the existing cards for the current context, you shouldn't generate same questions:
+    {{EXISTING_CARDS}}
+
 - Question Writing Guidelines
 
     Good question patterns:

--- a/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
+++ b/backend/openedx_ai_extensions/prompts/default_generate_flashcards.txt
@@ -18,7 +18,7 @@
     Cover a diverse range of concepts from the material — do not repeat the same idea across multiple cards.
     Each card must have a unique `id` in the format "card-1", "card-2", etc.
 
-    Here are the existing cards for the current context, you shouldn't generate same questions:
+    If any flashcards for the current context are provided below, treat them as existing cards and do not generate duplicate or highly similar questions. If no cards are provided, ignore this instruction:
     {{EXISTING_CARDS}}
 
 - Question Writing Guidelines

--- a/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from openedx_ai_extensions.processors import LLMProcessor, OpenEdXProcessor
 from openedx_ai_extensions.xapi.constants import EVENT_NAME_WORKFLOW_COMPLETED
 
-from .session_based_orchestrator import SessionBasedOrchestrator
+from .session_based_orchestrator import ScopedSessionOrchestrator
 
 
-class FlashCardsOrchestrator(SessionBasedOrchestrator):
+class FlashCardsOrchestrator(ScopedSessionOrchestrator):
     """
     Orchestrator for flashcards generation using LLM.
 
@@ -26,6 +26,32 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
             / "flashcards.json"
         )
 
+    def _get_structured_cards(self, cards):
+        """
+        Helper method to structure cards in a consistent format.
+        """
+        if isinstance(cards, dict):
+            potential_cards = cards.get('cards')
+            if isinstance(potential_cards, list):
+                cards = potential_cards
+
+        if cards is not None:
+            for card in cards:
+                if isinstance(card, dict):
+                    card['nextReviewTime'] = 0
+                    card['interval'] = 1
+                    card['easeFactor'] = 2.5
+                    card['repetitions'] = 0
+                    card['lastReviewedAt'] = None
+
+        if isinstance(cards, dict):
+            enriched_response = dict(cards)
+            enriched_response['cards'] = cards
+        else:
+            enriched_response = cards
+
+        return enriched_response
+
     def run(self, input_data):
         """
         Executes the content fetching, LLM processing, and handles streaming
@@ -33,6 +59,7 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         """
 
         # --- 1. Process with OpenEdX processor (Content Fetching) ---
+        self._set_status_message("Fetching unit content...")
         openedx_processor = OpenEdXProcessor(
             processor_config=self.profile.processor_config,
             location_id=self.location_id,
@@ -54,11 +81,26 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         if input_data.get('num_cards', None) is None:
             # Generate random number of cards between 1 and 25 if num_cards is not provided or is None
             input_data['num_cards'] = random.randint(1, 25)
+
+        if self.session.metadata.get('cards') is not None:
+            existing_cards_str = ""
+            for card in self.session.metadata['cards']:
+                if card.get('question') and card.get('answer'):
+                    card_id = card.get('id', 'N/A')
+                    question = card['question']
+                    answer = card['answer']
+                    existing_cards_str += (
+                        f"Id: {card_id}\nQuestion: {question}"
+                        f"\nAnswer: {answer}\n\n"
+                    )
+            input_data['existing_cards'] = existing_cards_str
+
         with open(self._schema_path, 'r', encoding='utf-8') as f:
             llm_processor = LLMProcessor(
                 config=self.profile.processor_config,
                 extra_params={"response_format": json.load(f)}
             )
+        self._set_status_message("Generating flashcards with LLM...")
         llm_result = llm_processor.process(
             context=llm_input_content,
             input_data=input_data,
@@ -73,31 +115,16 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         self._emit_workflow_event(EVENT_NAME_WORKFLOW_COMPLETED)
 
         response_obj = llm_result.get('response')
-        cards = []
-        if isinstance(response_obj, dict):
-            potential_cards = response_obj.get('cards')
-            if isinstance(potential_cards, list):
-                cards = potential_cards
-        elif isinstance(response_obj, list):
-            cards = response_obj
+        cards = self._get_structured_cards(response_obj)
 
-        if cards is not None:
-            for card in cards:
-                if isinstance(card, dict):
-                    card['nextReviewTime'] = 0
-                    card['interval'] = 1
-                    card['easeFactor'] = 2.5
-                    card['repetitions'] = 0
-                    card['lastReviewedAt'] = None
-
-        if isinstance(response_obj, dict):
-            enriched_response = dict(response_obj)
-            enriched_response['cards'] = cards
+        if self.session.metadata.get('cards') is None:
+            self.session.metadata['cards'] = cards
         else:
-            enriched_response = cards
+            self.session.metadata['cards'].extend(cards)
+        self.session.save(update_fields=['metadata'])
 
         response_data = {
-            'response': enriched_response,
+            'response': cards,
             'status': 'completed',
             'metadata': {
                 'tokens_used': llm_result.get('tokens_used'),
@@ -111,10 +138,19 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         Saves the generated flashcards to the database or a file.
         This is a placeholder implementation and should be replaced with actual saving logic.
         """
-        self.session.metadata['cards'] = input_data.get('cards') or input_data.get('card_stack')
+        cards = input_data.get('cards')
+        if cards is None:
+            card_stack = input_data.get('card_stack')
+            if isinstance(card_stack, dict):
+                cards = card_stack.get('cards')
+            else:
+                cards = card_stack
+        self.session.metadata['cards'] = cards
         self.session.save(update_fields=['metadata'])
+        num_cards = len(cards) if cards else 0
         return {
-            'status': 'flashcards_saved',
+            'status': 'saved',
+            'message': f'{num_cards} cards saved successfully.'
         }
 
     def get_current_session_response(self, _):
@@ -126,5 +162,11 @@ class FlashCardsOrchestrator(SessionBasedOrchestrator):
         """
         metadata = self.session.metadata or {}
         if "cards" in metadata:
-            return metadata["cards"]
-        return None
+            return {
+                'cards': metadata['cards'],
+                'status': 'completed',
+            }
+        return {
+            'cards': None,
+            'status': 'no_flashcards',
+        }

--- a/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/flashcards_orchestrator.py
@@ -31,26 +31,19 @@ class FlashCardsOrchestrator(ScopedSessionOrchestrator):
         Helper method to structure cards in a consistent format.
         """
         if isinstance(cards, dict):
-            potential_cards = cards.get('cards')
-            if isinstance(potential_cards, list):
-                cards = potential_cards
+            cards = cards.get('cards', [])
+        if not isinstance(cards, list):
+            cards = []
 
-        if cards is not None:
-            for card in cards:
-                if isinstance(card, dict):
-                    card['nextReviewTime'] = 0
-                    card['interval'] = 1
-                    card['easeFactor'] = 2.5
-                    card['repetitions'] = 0
-                    card['lastReviewedAt'] = None
+        for card in cards:
+            if isinstance(card, dict):
+                card['nextReviewTime'] = 0
+                card['interval'] = 1
+                card['easeFactor'] = 2.5
+                card['repetitions'] = 0
+                card['lastReviewedAt'] = None
 
-        if isinstance(cards, dict):
-            enriched_response = dict(cards)
-            enriched_response['cards'] = cards
-        else:
-            enriched_response = cards
-
-        return enriched_response
+        return cards
 
     def run(self, input_data):
         """
@@ -82,10 +75,12 @@ class FlashCardsOrchestrator(ScopedSessionOrchestrator):
             # Generate random number of cards between 1 and 25 if num_cards is not provided or is None
             input_data['num_cards'] = random.randint(1, 25)
 
-        if self.session.metadata.get('cards') is not None:
+        metadata = self.session.metadata or {}
+        existing_cards = metadata.get('cards')
+        if isinstance(existing_cards, list):
             existing_cards_str = ""
-            for card in self.session.metadata['cards']:
-                if card.get('question') and card.get('answer'):
+            for card in existing_cards:
+                if isinstance(card, dict) and card.get('question') and card.get('answer'):
                     card_id = card.get('id', 'N/A')
                     question = card['question']
                     answer = card['answer']
@@ -117,10 +112,11 @@ class FlashCardsOrchestrator(ScopedSessionOrchestrator):
         response_obj = llm_result.get('response')
         cards = self._get_structured_cards(response_obj)
 
-        if self.session.metadata.get('cards') is None:
-            self.session.metadata['cards'] = cards
+        existing_cards = self.session.metadata.get('cards')
+        if isinstance(existing_cards, list):
+            existing_cards.extend(cards)
         else:
-            self.session.metadata['cards'].extend(cards)
+            self.session.metadata['cards'] = cards
         self.session.save(update_fields=['metadata'])
 
         response_data = {

--- a/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
@@ -207,3 +207,22 @@ class SessionBasedOrchestrator(BaseOrchestrator):
             return {
                 'status': 'idle',
             }
+
+
+class ScopedSessionOrchestrator(SessionBasedOrchestrator):  # pylint: disable=abstract-method
+    """
+    Orchestrator that follows the scope's location specificity for sessions.
+
+    Intentionally skips ``SessionBasedOrchestrator.__init__`` to avoid creating
+    a location-specific session; instead creates a course-scoped session
+    shared across locations.
+    """
+
+    def __init__(self, workflow, user, context):  # pylint: disable=super-init-not-called
+        BaseOrchestrator.__init__(self, workflow, user, context)  # pylint: disable=non-parent-init-called
+        self.session, _ = AIWorkflowSession.objects.get_or_create(
+            user=self.user,
+            scope=self.workflow,
+            profile=self.workflow.profile,
+            course_id=self.course_id,
+        )

--- a/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
+++ b/backend/openedx_ai_extensions/workflows/orchestrators/session_based_orchestrator.py
@@ -42,9 +42,11 @@ def _execute_orchestrator_async(task_self, session_id, action, params=None):
         session = AIWorkflowSession.objects.select_related('scope', 'profile', 'user').get(id=session_id)
 
         # 2. Build context from session
+        metadata = session.metadata or {}
+        location_id = metadata.get('location_id') or session.location_id
         context = {
             'course_id': str(session.course_id) if session.course_id is not None else None,
-            'location_id': str(session.location_id) if session.location_id is not None else None,
+            'location_id': str(location_id) if location_id is not None else None,
         }
 
         # 3. Resolve and instantiate orchestrator via centralized factory
@@ -226,3 +228,37 @@ class ScopedSessionOrchestrator(SessionBasedOrchestrator):  # pylint: disable=ab
             profile=self.workflow.profile,
             course_id=self.course_id,
         )
+
+    def run_async(self, input_data):
+        """
+        Launch async task for scoped sessions.
+
+        Unlike the parent implementation, this does **not** write
+        ``location_id`` to the session row (which has no location_id in its
+        unique-together lookup).  Instead the current location is persisted
+        in ``metadata['location_id']`` so the Celery task can recover it
+        without risking an integrity-error collision with any pre-existing
+        location-scoped session.
+        """
+        self.session.course_id = self.course_id
+        self.session.metadata = self.session.metadata or {}
+        self.session.metadata['task_status'] = 'processing'
+        self.session.metadata['location_id'] = self.location_id
+        self.session.metadata.pop('task_result', None)
+        self.session.metadata.pop('task_error', None)
+        self.session.metadata.pop('task_status_message', None)
+        self.session.save()
+
+        task = _execute_orchestrator_async.delay(
+            session_id=self.session.id,
+            action='run',
+            params={
+                "input_data": input_data,
+            }
+        )
+
+        return {
+            'status': 'processing',
+            'task_id': task.id,
+            'message': 'AI workflow has started'
+        }

--- a/backend/tests/test_flashcards_orchestrator.py
+++ b/backend/tests/test_flashcards_orchestrator.py
@@ -456,8 +456,8 @@ def test_run_dict_response_no_cards_key(
     flashcards_orchestrator,  # pylint: disable=redefined-outer-name
 ):
     """
-    When response is a dict but has no 'cards' key, enriched_response wraps
-    the original dict and adds a 'cards' key referencing it.
+    When the LLM response is a dict without a 'cards' key, it is treated as
+    having no cards — the result contains an empty list.
     """
     mock_openedx = Mock()
     mock_openedx.process.return_value = {"content": "course content"}
@@ -475,8 +475,7 @@ def test_run_dict_response_no_cards_key(
         result = flashcards_orchestrator.run({"num_cards": 1})
 
     assert result["status"] == "completed"
-    assert isinstance(result["response"], dict)
-    assert result["response"]["other_data"] == "value"
+    assert result["response"] == []
 
 
 # ===========================================================================
@@ -511,8 +510,8 @@ def test_run_none_response(
         result = flashcards_orchestrator.run({"num_cards": 1})
 
     assert result["status"] == "completed"
-    # None is neither dict nor list, so enriched_response = cards = None
-    assert result["response"] is None
+    # None is normalized to an empty list by _get_structured_cards
+    assert result["response"] == []
 
 
 # ===========================================================================
@@ -742,3 +741,129 @@ def test_run_passes_content_and_input_data_to_llm(
     call_kwargs = mock_llm.process.call_args[1]
     assert call_kwargs["context"] == str(content_data)
     assert call_kwargs["input_data"] == input_data
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — existing cards are sent as context (lines 86-96)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_existing_cards_passed_as_context(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When session already contains cards, run() builds an existing_cards string
+    and includes it in input_data so the LLM avoids duplicates.
+    """
+    existing = [
+        {"id": "card-1", "question": "What is 2+2?", "answer": "4"},
+        {"id": "card-2", "question": "Capital of France?", "answer": "Paris"},
+    ]
+    flashcards_orchestrator.session.metadata = {"cards": existing}
+    flashcards_orchestrator.session.save(update_fields=["metadata"])
+
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": [{"id": "card-3", "question": "Q3?", "answer": "A3"}]},
+        "tokens_used": 50,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        flashcards_orchestrator.run({"num_cards": 1})
+
+    call_kwargs = mock_llm.process.call_args[1]
+    existing_cards_str = call_kwargs["input_data"]["existing_cards"]
+    assert "Id: card-1" in existing_cards_str
+    assert "Question: What is 2+2?" in existing_cards_str
+    assert "Answer: 4" in existing_cards_str
+    assert "Id: card-2" in existing_cards_str
+    assert "Question: Capital of France?" in existing_cards_str
+    assert "Answer: Paris" in existing_cards_str
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.run — new cards extend existing (line 123)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.OpenEdXProcessor")
+@patch("openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.LLMProcessor")
+def test_run_extends_existing_cards_in_session(
+    mock_llm_class,
+    mock_openedx_class,
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When session already has cards, run() extends the list rather than
+    replacing it.
+    """
+    existing = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+    ]
+    flashcards_orchestrator.session.metadata = {"cards": existing}
+    flashcards_orchestrator.session.save(update_fields=["metadata"])
+
+    mock_openedx = Mock()
+    mock_openedx.process.return_value = {"content": "course content"}
+    mock_openedx_class.return_value = mock_openedx
+
+    new_cards = [
+        {"id": "card-2", "question": "Q2?", "answer": "A2"},
+    ]
+    mock_llm = Mock()
+    mock_llm.process.return_value = {
+        "response": {"cards": new_cards},
+        "tokens_used": 50,
+        "model_used": "openai/gpt-4",
+    }
+    mock_llm_class.return_value = mock_llm
+
+    with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
+        flashcards_orchestrator.run({"num_cards": 1})
+
+    flashcards_orchestrator.session.refresh_from_db()
+    stored = flashcards_orchestrator.session.metadata["cards"]
+    assert len(stored) == 2
+    assert stored[0]["id"] == "card-1"
+    assert stored[1]["id"] == "card-2"
+
+
+# ===========================================================================
+# FlashCardsOrchestrator.save — card_stack dict unwrapping (line 145)
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_save_unwraps_card_stack_dict(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    When 'card_stack' is a dict containing a 'cards' key, save() extracts
+    the inner list instead of storing the wrapper dict.
+    """
+    flashcards_orchestrator.session.metadata = {}
+
+    inner_cards = [
+        {"id": "card-1", "question": "Q1?", "answer": "A1"},
+        {"id": "card-2", "question": "Q2?", "answer": "A2"},
+    ]
+    card_stack = {"cards": inner_cards, "created_at": 12345, "last_studied_at": 67890}
+    result = flashcards_orchestrator.save({"card_stack": card_stack})
+
+    assert result["status"] == "saved"
+    assert result["message"] == "2 cards saved successfully."
+
+    flashcards_orchestrator.session.refresh_from_db()
+    assert flashcards_orchestrator.session.metadata["cards"] == inner_cards

--- a/backend/tests/test_flashcards_orchestrator.py
+++ b/backend/tests/test_flashcards_orchestrator.py
@@ -88,7 +88,7 @@ def test_get_current_session_response_with_cards(
     flashcards_orchestrator.session.metadata = {"cards": cards}
 
     result = flashcards_orchestrator.get_current_session_response(None)
-    assert result == cards
+    assert result == {'cards': cards, 'status': 'completed'}
 
 
 @pytest.mark.django_db
@@ -101,7 +101,7 @@ def test_get_current_session_response_no_cards(
     flashcards_orchestrator.session.metadata = {}
 
     result = flashcards_orchestrator.get_current_session_response(None)
-    assert result is None
+    assert result == {'cards': None, 'status': 'no_flashcards'}
 
 
 @pytest.mark.django_db
@@ -114,7 +114,7 @@ def test_get_current_session_response_none_metadata(
     flashcards_orchestrator.session.metadata = None
 
     result = flashcards_orchestrator.get_current_session_response(None)
-    assert result is None
+    assert result == {'cards': None, 'status': 'no_flashcards'}
 
 
 # ===========================================================================
@@ -213,7 +213,8 @@ def test_run_success_dict_response(
     assert result["metadata"]["tokens_used"] == 200
     assert result["metadata"]["model_used"] == "openai/gpt-4"
 
-    enriched_cards = result["response"]["cards"]
+    enriched_cards = result["response"]
+    assert isinstance(enriched_cards, list)
     assert len(enriched_cards) == 2
     for card in enriched_cards:
         assert card["nextReviewTime"] == 0
@@ -438,7 +439,7 @@ def test_run_success_empty_cards(
         result = flashcards_orchestrator.run({"num_cards": 0})
 
     assert result["status"] == "completed"
-    assert result["response"]["cards"] == []
+    assert result["response"] == []
 
 
 # ===========================================================================
@@ -455,8 +456,8 @@ def test_run_dict_response_no_cards_key(
     flashcards_orchestrator,  # pylint: disable=redefined-outer-name
 ):
     """
-    When response is a dict but has no 'cards' key, enriched_response should
-    still be a dict with an empty cards list.
+    When response is a dict but has no 'cards' key, enriched_response wraps
+    the original dict and adds a 'cards' key referencing it.
     """
     mock_openedx = Mock()
     mock_openedx.process.return_value = {"content": "course content"}
@@ -474,7 +475,8 @@ def test_run_dict_response_no_cards_key(
         result = flashcards_orchestrator.run({"num_cards": 1})
 
     assert result["status"] == "completed"
-    assert result["response"]["cards"] == []
+    assert isinstance(result["response"], dict)
+    assert result["response"]["other_data"] == "value"
 
 
 # ===========================================================================
@@ -509,8 +511,8 @@ def test_run_none_response(
         result = flashcards_orchestrator.run({"num_cards": 1})
 
     assert result["status"] == "completed"
-    # None is neither dict nor list, so enriched_response = cards = []
-    assert result["response"] == []
+    # None is neither dict nor list, so enriched_response = cards = None
+    assert result["response"] is None
 
 
 # ===========================================================================
@@ -533,7 +535,7 @@ def test_save_stores_cards_in_session(
     ]
     result = flashcards_orchestrator.save({"cards": cards})
 
-    assert result["status"] == "flashcards_saved"
+    assert result["status"] == "saved"
 
     flashcards_orchestrator.session.refresh_from_db()
     assert flashcards_orchestrator.session.metadata["cards"] == cards
@@ -553,7 +555,7 @@ def test_save_stores_card_stack_fallback(
     ]
     result = flashcards_orchestrator.save({"card_stack": card_stack})
 
-    assert result["status"] == "flashcards_saved"
+    assert result["status"] == "saved"
 
     flashcards_orchestrator.session.refresh_from_db()
     assert flashcards_orchestrator.session.metadata["cards"] == card_stack
@@ -572,7 +574,7 @@ def test_save_prefers_cards_over_card_stack(
     card_stack = [{"id": "card-2", "question": "Q2?", "answer": "A2"}]
     result = flashcards_orchestrator.save({"cards": cards, "card_stack": card_stack})
 
-    assert result["status"] == "flashcards_saved"
+    assert result["status"] == "saved"
 
     flashcards_orchestrator.session.refresh_from_db()
     assert flashcards_orchestrator.session.metadata["cards"] == cards
@@ -589,7 +591,8 @@ def test_save_with_no_cards_or_card_stack(
 
     result = flashcards_orchestrator.save({})
 
-    assert result["status"] == "flashcards_saved"
+    assert result["status"] == "saved"
+    assert result["message"] == "0 cards saved successfully."
 
     flashcards_orchestrator.session.refresh_from_db()
     assert flashcards_orchestrator.session.metadata["cards"] is None
@@ -645,7 +648,7 @@ def test_run_card_enrichment_preserves_original_fields(
     with patch.object(flashcards_orchestrator, "_emit_workflow_event"):
         result = flashcards_orchestrator.run({"num_cards": 1})
 
-    card = result["response"]["cards"][0]
+    card = result["response"][0]
     # Original fields preserved
     assert card["id"] == "card-1"
     assert card["question"] == "What is DNA?"
@@ -695,7 +698,8 @@ def test_run_non_dict_card_items_are_skipped(
         result = flashcards_orchestrator.run({"num_cards": 1})
 
     assert result["status"] == "completed"
-    enriched_cards = result["response"]["cards"]
+    enriched_cards = result["response"]
+    assert isinstance(enriched_cards, list)
     # Only the dict item gets enriched
     assert "nextReviewTime" in enriched_cards[0]
     assert enriched_cards[1] == "not-a-dict"

--- a/backend/tests/test_flashcards_orchestrator.py
+++ b/backend/tests/test_flashcards_orchestrator.py
@@ -867,3 +867,61 @@ def test_save_unwraps_card_stack_dict(
 
     flashcards_orchestrator.session.refresh_from_db()
     assert flashcards_orchestrator.session.metadata["cards"] == inner_cards
+
+
+# ===========================================================================
+# ScopedSessionOrchestrator — session scoping & run_async
+# ===========================================================================
+
+
+@pytest.mark.django_db
+def test_scoped_session_has_no_location_id(
+    flashcards_orchestrator,  # pylint: disable=redefined-outer-name
+):
+    """
+    ScopedSessionOrchestrator creates a session without location_id so it is
+    shared across all locations within the same course.
+    """
+    assert flashcards_orchestrator.session.location_id is None
+
+
+@pytest.mark.django_db
+@patch(
+    "openedx_ai_extensions.workflows.orchestrators.session_based_orchestrator"
+    "._execute_orchestrator_async"
+)
+def test_scoped_run_async_stores_location_in_metadata(
+    mock_task,
+    workflow_scope,  # pylint: disable=redefined-outer-name
+    user,  # pylint: disable=redefined-outer-name
+    course_key,  # pylint: disable=redefined-outer-name
+):
+    """
+    ScopedSessionOrchestrator.run_async persists the current location_id in
+    metadata (not on the session row) so the async task can recover it
+    without risking a unique-constraint collision.
+    """
+    location = "block-v1:edX+DemoX+Demo_Course+type@vertical+block@test_unit_1"
+    context = {
+        "course_id": str(course_key),
+        "location_id": location,
+    }
+    orchestrator = FlashCardsOrchestrator(
+        workflow=workflow_scope,
+        user=user,
+        context=context,
+    )
+
+    mock_task.delay.return_value = Mock(id="celery-task-id-123")
+    result = orchestrator.run_async({"num_cards": 5})
+
+    assert result["status"] == "processing"
+    assert result["task_id"] == "celery-task-id-123"
+
+    # location_id must NOT be written to the session row
+    orchestrator.session.refresh_from_db()
+    assert orchestrator.session.location_id is None
+
+    # location_id must be stored in metadata for the async task
+    assert orchestrator.session.metadata["location_id"] == location
+    assert orchestrator.session.metadata["task_status"] == "processing"

--- a/frontend/src/flashcard-study/components/FlashcardCreator.test.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardCreator.test.tsx
@@ -35,20 +35,28 @@ beforeEach(() => {
   });
 });
 
-// Helper: open form and click a depth option
-const openFormAndGenerate = async (user: ReturnType<typeof userEvent.setup>, label = 'Auto') => {
+const clickCreateButton = async (user: ReturnType<typeof userEvent.setup>) => {
   await user.click(screen.getByRole('button', { name: /create new cards/i }));
-  await user.click(screen.getByText(label));
+};
+
+const clickAutoDepth = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole('button', { name: /auto/i }));
+};
+
+const generateWithAuto = async (user: ReturnType<typeof userEvent.setup>) => {
+  await clickCreateButton(user);
+  await clickAutoDepth(user);
 };
 
 describe('FlashcardCreator', () => {
   describe('when preloadPreviousSession is enabled', () => {
-    it('shows a loading spinner while checking', () => {
+    it('shows a loading state while checking', () => {
       (getSessionResponse as jest.Mock).mockReturnValue(new Promise(() => {}));
       render(<FlashcardCreator {...defaultProps} preloadPreviousSession />);
 
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText('Loading', { selector: '.small' })).toBeInTheDocument();
+      const btn = screen.getByRole('button', { name: /loading/i });
+      expect(btn).toBeInTheDocument();
+      expect(btn).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('hands off to the response component when a session with cards exists', async () => {
@@ -99,6 +107,17 @@ describe('FlashcardCreator', () => {
       expect(screen.getByRole('button', { name: /create new cards/i })).toBeInTheDocument();
     });
 
+    it('shows the generate form when the create button is clicked', async () => {
+      const user = userEvent.setup();
+      render(<FlashcardCreator {...defaultProps} />);
+
+      await clickCreateButton(user);
+
+      expect(screen.getByText(/choose a study depth/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /auto/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /^5 cards/i })).toBeInTheDocument();
+    });
+
     it('hides the component when the response is already shown', () => {
       const { container } = render(<FlashcardCreator {...defaultProps} hasAsked />);
       expect(container).toBeEmptyDOMElement();
@@ -106,26 +125,44 @@ describe('FlashcardCreator', () => {
   });
 
   describe('when the user creates new flashcards', () => {
-    it('opens the depth selector and hides the action button', async () => {
-      const user = userEvent.setup();
-      render(<FlashcardCreator {...defaultProps} />);
-
-      await user.click(screen.getByRole('button', { name: /create new cards/i }));
-
-      expect(screen.getByText(/choose a study depth/i)).toBeInTheDocument();
-      expect(screen.getByText('Auto')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /create new cards/i })).not.toBeInTheDocument();
-    });
-
-    it('shows a spinner after clicking a depth option', async () => {
+    it('shows generating state after clicking a depth option', async () => {
       const user = userEvent.setup();
       (generateFlashcards as jest.Mock).mockReturnValue(new Promise(() => {}));
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
-      expect(screen.getByRole('status')).toBeInTheDocument();
-      expect(screen.getByText('Generating', { selector: '.small' })).toBeInTheDocument();
+      const btn = screen.getByRole('button');
+      expect(btn).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('calls generateFlashcards with null numCards for auto depth', async () => {
+      const user = userEvent.setup();
+      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-1' });
+      render(<FlashcardCreator {...defaultProps} />);
+
+      await generateWithAuto(user);
+
+      await waitFor(() => {
+        expect(generateFlashcards).toHaveBeenCalledWith(
+          expect.objectContaining({ numCards: null }),
+        );
+      });
+    });
+
+    it('calls generateFlashcards with specific numCards for a depth option', async () => {
+      const user = userEvent.setup();
+      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-1' });
+      render(<FlashcardCreator {...defaultProps} />);
+
+      await clickCreateButton(user);
+      await user.click(screen.getByRole('button', { name: /^5 cards/i }));
+
+      await waitFor(() => {
+        expect(generateFlashcards).toHaveBeenCalledWith(
+          expect.objectContaining({ numCards: 5 }),
+        );
+      });
     });
 
     it('starts polling when the backend returns a task ID', async () => {
@@ -133,38 +170,10 @@ describe('FlashcardCreator', () => {
       (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-123' });
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
       await waitFor(() => {
         expect(mockStartPolling).toHaveBeenCalledWith('task-123');
-      });
-    });
-
-    it('sends the selected preset number of cards to the API', async () => {
-      const user = userEvent.setup();
-      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-1' });
-      render(<FlashcardCreator {...defaultProps} />);
-
-      await openFormAndGenerate(user, '15 cards');
-
-      await waitFor(() => {
-        expect(generateFlashcards).toHaveBeenCalledWith(
-          expect.objectContaining({ numCards: 15 }),
-        );
-      });
-    });
-
-    it('sends null for auto-generation when Auto is clicked', async () => {
-      const user = userEvent.setup();
-      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-1' });
-      render(<FlashcardCreator {...defaultProps} />);
-
-      await openFormAndGenerate(user);
-
-      await waitFor(() => {
-        expect(generateFlashcards).toHaveBeenCalledWith(
-          expect.objectContaining({ numCards: null }),
-        );
       });
     });
 
@@ -174,7 +183,7 @@ describe('FlashcardCreator', () => {
       (generateFlashcards as jest.Mock).mockResolvedValue(responseData);
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
       await waitFor(() => {
         expect(defaultProps.setResponse).toHaveBeenCalledWith(responseData);
@@ -187,21 +196,44 @@ describe('FlashcardCreator', () => {
       (generateFlashcards as jest.Mock).mockRejectedValue(new Error('Server error'));
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
       await waitFor(() => {
         expect(screen.getByText(/failed to generate flashcards/i)).toBeInTheDocument();
       });
     });
+
+    it('displays backend progress message during polling', async () => {
+      let capturedOnProgress: (msg: string) => void;
+      (useAsyncTaskPolling as jest.Mock).mockImplementation((opts: any) => {
+        capturedOnProgress = opts.onProgress;
+        return { startPolling: mockStartPolling, stopPolling: mockStopPolling };
+      });
+      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-456', message: 'Reading unit...' });
+      const user = userEvent.setup();
+      render(<FlashcardCreator {...defaultProps} />);
+
+      await generateWithAuto(user);
+
+      await waitFor(() => {
+        expect(screen.getByText('Reading unit...')).toBeInTheDocument();
+      });
+
+      capturedOnProgress!('Building cards...');
+
+      await waitFor(() => {
+        expect(screen.getByText('Building cards...')).toBeInTheDocument();
+      });
+    });
   });
 
   describe('when the user encounters an error', () => {
-    it('can return to the initial screen by clicking Start Over', async () => {
+    it('can return to the initial screen by dismissing the error', async () => {
       const user = userEvent.setup();
       (generateFlashcards as jest.Mock).mockRejectedValue(new Error('fail'));
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();
@@ -213,12 +245,12 @@ describe('FlashcardCreator', () => {
       expect(screen.queryByText(/failed to generate/i)).not.toBeInTheDocument();
     });
 
-    it('stops polling when Start Over is clicked', async () => {
+    it('stops polling when dismissed', async () => {
       const user = userEvent.setup();
       (generateFlashcards as jest.Mock).mockRejectedValue(new Error('fail'));
       render(<FlashcardCreator {...defaultProps} />);
 
-      await openFormAndGenerate(user);
+      await generateWithAuto(user);
 
       await waitFor(() => {
         expect(screen.getByRole('button', { name: /dismiss/i })).toBeInTheDocument();

--- a/frontend/src/flashcard-study/components/FlashcardCreator.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardCreator.tsx
@@ -1,11 +1,9 @@
 import {
-  useState, useCallback, useEffect, useMemo,
+  useState, useCallback, useEffect, useMemo, useRef,
 } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Alert, Button, Spinner,
-} from '@openedx/paragon';
-import { AutoAwesome } from '@openedx/paragon/icons';
+import { Alert, Icon, StatefulButton } from '@openedx/paragon';
+import { AutoAwesome, SpinnerSimple } from '@openedx/paragon/icons';
 import { POLLING_ERROR_KEYS, useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
 import { generateFlashcards, getSessionResponse } from '../data/workflowActions';
 import { prepareContextData } from '../../services';
@@ -45,7 +43,9 @@ const FlashcardCreator = ({
   const intl = useIntl();
   const [step, setStep] = useState<FlashcardStep>(preloadPreviousSession ? 'loading' : 'idle');
   const [showForm, setShowForm] = useState(false);
+  const numCardsRef = useRef<number | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
+  const [progressMessage, setProgressMessage] = useState('');
 
   const contextData = useMemo(
     () => prepareContextData({ courseId, locationId, uiSlotSelectorId }),
@@ -54,21 +54,28 @@ const FlashcardCreator = ({
 
   const onComplete = useCallback((responseData: any) => {
     setStep('idle');
-    setResponse(responseData);
+    setProgressMessage('');
+    setResponse({ cards: responseData, numCards: numCardsRef.current });
     setHasAsked(true);
   }, [setResponse, setHasAsked]);
 
   const onError = useCallback((errorKey: string) => {
     setStep('error');
+    setProgressMessage('');
     const messageKey = ERROR_MESSAGES[errorKey] || 'ai.extensions.flashcard.error.generate';
     setErrorMessage(intl.formatMessage(messages[messageKey]));
   }, [intl]);
+
+  const onProgress = useCallback((message: string) => {
+    setProgressMessage(message);
+  }, []);
 
   const { startPolling, stopPolling } = useAsyncTaskPolling({
     contextData,
     courseId,
     onComplete,
     onError,
+    onProgress,
   });
 
   // Check for existing session on mount
@@ -95,13 +102,16 @@ const FlashcardCreator = ({
     return () => { cancelled = true; };
   }, [contextData, setResponse, setHasAsked, preloadPreviousSession]);
 
-  const handleGenerate = async (numCards: number | null) => {
-    setStep('generating');
+  const handleGenerate = async (selectedNumCards: number | null) => {
+    numCardsRef.current = selectedNumCards;
     setShowForm(false);
+    setStep('generating');
+    setProgressMessage('');
     try {
-      const data = await generateFlashcards({ context: contextData, numCards });
+      const data = await generateFlashcards({ context: contextData, numCards: selectedNumCards });
       if (data.taskId) {
         startPolling(data.taskId);
+        if (data.message) { setProgressMessage(data.message); }
       } else {
         setResponse(data);
         setHasAsked(true);
@@ -116,68 +126,52 @@ const FlashcardCreator = ({
   const handleStartOver = () => {
     stopPolling();
     setStep('idle');
-    setShowForm(false);
     setErrorMessage('');
+    setProgressMessage('');
   };
 
   if (hasAsked) { return null; }
 
   return (
-    <div className="flashcard-creator my-2 py-3 border-bottom d-flex justify-content-between align-items-center flex-wrap">
-      {step === 'loading' && (
-        <div className="text-center py-3 mx-auto">
-          <Spinner animation="border" size="sm" className="mr-2" screenReaderText={intl.formatMessage(messages['ai.extensions.flashcard.creator.loading'])} />
-          <span className="small">
-            {intl.formatMessage(messages['ai.extensions.flashcard.creator.loading'])}
-          </span>
-        </div>
-      )}
+    <div className="flashcard-creator d-flex align-items-center justify-content-end px-3 small flex-wrap">
 
-      {step === 'idle' && (
+      { (!errorMessage && showForm) ? (
+        <GenerateForm onGenerate={handleGenerate} isLoading={false} />
+      ) : (
         <>
-          {!showForm && (
-            <>
-              <small className="d-block mb-2">
-                {customMessage || intl.formatMessage(messages['ai.extensions.flashcard.creator.description'])}
-              </small>
-              <Button
-                variant="primary"
-                size="sm"
-                iconBefore={AutoAwesome}
-                onClick={() => setShowForm(true)}
-              >
-                {buttonText || intl.formatMessage(messages['ai.extensions.flashcard.creator.create.button'])}
-              </Button>
-            </>
-          )}
-
-          {showForm && (
-            <GenerateForm
-              onGenerate={handleGenerate}
-              isLoading={false}
-            />
-          )}
+          <small className="d-block my-2 pr-md-5 container-mw-xs">
+            {customMessage || intl.formatMessage(messages['ai.extensions.flashcard.creator.description'])}
+          </small>
+          <StatefulButton
+            variant="primary"
+            size="sm"
+            state={step}
+            onClick={() => setShowForm(!showForm)}
+            labels={{
+              default: buttonText || intl.formatMessage(messages['ai.extensions.flashcard.creator.create.button']),
+              generating: progressMessage || intl.formatMessage(messages['ai.extensions.flashcard.generating']),
+              loading: intl.formatMessage(messages['ai.extensions.flashcard.creator.loading']),
+            }}
+            icons={{
+              default: <Icon src={AutoAwesome} />,
+              generating: <Icon src={SpinnerSimple} className="icon-spin" />,
+              loading: <Icon src={SpinnerSimple} className="icon-spin" />,
+            }}
+            disabledStates={['loading', 'generating']}
+          />
         </>
       )}
-
-      {step === 'generating' && (
-        <div className="text-center py-3 mx-auto">
-          <Spinner animation="border" size="sm" className="mr-2" screenReaderText={intl.formatMessage(messages['ai.extensions.flashcard.generate.form.generating'])} />
-          <span className="small">
-            {intl.formatMessage(messages['ai.extensions.flashcard.generate.form.generating'])}
-          </span>
-        </div>
-      )}
-
-      {step === 'error' && (
-      <Alert
-        variant="danger"
-        dismissible
-        onClose={handleStartOver}
-        className="w-100"
-      >{errorMessage}
-      </Alert>
-      )}
+      {
+        step === 'error' && (
+          <Alert
+            variant="danger"
+            dismissible
+            onClose={handleStartOver}
+            className="w-100"
+          >{errorMessage}
+          </Alert>
+        )
+      }
     </div>
   );
 };

--- a/frontend/src/flashcard-study/components/FlashcardStudyResponse.test.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardStudyResponse.test.tsx
@@ -2,13 +2,24 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWrapper as render } from '../../setupTest';
 import FlashcardStudyResponse from './FlashcardStudyResponse';
-import { saveCardStack, clearSession } from '../data/workflowActions';
+import { saveCardStack, generateFlashcards } from '../data/workflowActions';
 import { Flashcard } from '../types';
 
 jest.mock('../data/workflowActions', () => ({
   saveCardStack: jest.fn().mockResolvedValue({}),
-  clearSession: jest.fn().mockResolvedValue({}),
+  generateFlashcards: jest.fn().mockResolvedValue({}),
 }));
+
+jest.mock('../hooks/useAsyncTaskPolling', () => {
+  const actual = jest.requireActual('../hooks/useAsyncTaskPolling');
+  return {
+    ...actual,
+    useAsyncTaskPolling: jest.fn().mockReturnValue({
+      startPolling: jest.fn(),
+      stopPolling: jest.fn(),
+    }),
+  };
+});
 
 const makeDueCard = (overrides: Partial<Flashcard> = {}): Flashcard => ({
   id: '1',
@@ -44,7 +55,7 @@ const defaultProps = {
 beforeEach(() => {
   jest.clearAllMocks();
   (saveCardStack as jest.Mock).mockResolvedValue({});
-  (clearSession as jest.Mock).mockResolvedValue({});
+  (generateFlashcards as jest.Mock).mockResolvedValue({});
 });
 
 describe('FlashcardStudyResponse', () => {
@@ -72,25 +83,25 @@ describe('FlashcardStudyResponse', () => {
   });
 
   describe('when the response has no cards', () => {
-    it('shows an empty state with only a generate new set button', () => {
+    it('shows generate button but not practice button', () => {
       render(
         <FlashcardStudyResponse {...defaultProps} response={{ cards: [] }} />,
       );
-      expect(screen.getByText(/no flashcards found/i)).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /generate new set/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /generate unit cards/i })).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: /let's practice/i })).not.toBeInTheDocument();
     });
 
-    it('clears the backend session and resets when generate new set is clicked', async () => {
+    it('calls generateFlashcards with numCards from the response', async () => {
+      (generateFlashcards as jest.Mock).mockReturnValue(new Promise(() => {}));
       const user = userEvent.setup();
       render(
-        <FlashcardStudyResponse {...defaultProps} response={{ cards: [] }} />,
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [], numCards: 5 }} />,
       );
-      await user.click(screen.getByRole('button', { name: /generate new set/i }));
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
 
-      await waitFor(() => {
-        expect(clearSession).toHaveBeenCalledWith({ context: defaultProps.contextData });
-        expect(defaultProps.onClear).toHaveBeenCalled();
+      expect(generateFlashcards).toHaveBeenCalledWith({
+        context: defaultProps.contextData,
+        numCards: 5,
       });
     });
   });
@@ -112,7 +123,7 @@ describe('FlashcardStudyResponse', () => {
       );
 
       expect(screen.getByRole('button', { name: /let's practice/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /generate new set/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /generate unit cards/i })).toBeInTheDocument();
     });
 
     it('opens the modal when the user clicks let\'s practice', async () => {
@@ -392,7 +403,7 @@ describe('FlashcardStudyResponse', () => {
       expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
       expect(screen.getByText(/use your flashcards to review/i)).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /let's practice/i })).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: /generate new set/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /generate unit cards/i })).toBeInTheDocument();
     });
 
     it('reopens the modal when display cards is clicked from paused state', async () => {
@@ -410,7 +421,8 @@ describe('FlashcardStudyResponse', () => {
       expect(screen.getByText('What is React?')).toBeInTheDocument();
     });
 
-    it('clears backend session when clear session is clicked from paused state', async () => {
+    it('calls generateFlashcards when generate new set is clicked from paused state', async () => {
+      (generateFlashcards as jest.Mock).mockReturnValue(new Promise(() => {}));
       const user = userEvent.setup();
       const card = makeDueCard();
       render(
@@ -419,11 +431,132 @@ describe('FlashcardStudyResponse', () => {
       await openModal(user);
 
       await user.click(screen.getByRole('button', { name: /^done$/i }));
-      await user.click(screen.getByRole('button', { name: /generate new set/i }));
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      expect(generateFlashcards).toHaveBeenCalledWith({
+        context: defaultProps.contextData,
+        numCards: null,
+      });
+    });
+  });
+
+  describe('generation flow', () => {
+    it('calls generateFlashcards when generate new set is clicked', async () => {
+      (generateFlashcards as jest.Mock).mockReturnValue(new Promise(() => {}));
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      expect(generateFlashcards).toHaveBeenCalledWith({
+        context: defaultProps.contextData,
+        numCards: null,
+      });
+    });
+
+    it('shows spinner during generation', async () => {
+      (generateFlashcards as jest.Mock).mockReturnValue(new Promise(() => {}));
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
 
       await waitFor(() => {
-        expect(clearSession).toHaveBeenCalledWith({ context: defaultProps.contextData });
-        expect(defaultProps.onClear).toHaveBeenCalled();
+        expect(screen.getAllByText(/generating/i).length).toBeGreaterThan(0);
+      });
+    });
+
+    it('appends new cards on direct response', async () => {
+      const newCards = [
+        makeDueCard({ id: '10', question: 'New Q1', answer: 'New A1' }),
+      ];
+      (generateFlashcards as jest.Mock).mockResolvedValue({ cards: newCards });
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /generate unit cards/i })).not.toBeDisabled();
+      });
+
+      // Due badge should reflect original + new cards
+      await user.click(screen.getByRole('button', { name: /let's practice/i }));
+      // First due card is the original, new card is appended
+      expect(screen.getByText('What is React?')).toBeInTheDocument();
+    });
+
+    it('shows dismissible error alert on generation failure', async () => {
+      (generateFlashcards as jest.Mock).mockRejectedValue(new Error('fail'));
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to generate/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /dismiss/i }));
+      expect(screen.queryByText(/failed to generate/i)).not.toBeInTheDocument();
+    });
+
+    it('starts polling when taskId is returned', async () => {
+      const { useAsyncTaskPolling } = jest.requireMock('../hooks/useAsyncTaskPolling');
+      const mockStartPolling = jest.fn();
+      useAsyncTaskPolling.mockReturnValue({ startPolling: mockStartPolling, stopPolling: jest.fn() });
+
+      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-123' });
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      await waitFor(() => {
+        expect(mockStartPolling).toHaveBeenCalledWith('task-123');
+      });
+    });
+
+    it('displays backend progress message during polling', async () => {
+      const { useAsyncTaskPolling } = jest.requireMock('../hooks/useAsyncTaskPolling');
+      let capturedOnProgress: (msg: string) => void;
+      useAsyncTaskPolling.mockImplementation((opts: any) => {
+        capturedOnProgress = opts.onProgress;
+        return { startPolling: jest.fn(), stopPolling: jest.fn() };
+      });
+
+      (generateFlashcards as jest.Mock).mockResolvedValue({ taskId: 'task-456', message: 'Analyzing content...' });
+      const user = userEvent.setup();
+      const card = makeDueCard();
+      render(
+        <FlashcardStudyResponse {...defaultProps} response={{ cards: [card] }} />,
+      );
+
+      await user.click(screen.getByRole('button', { name: /generate unit cards/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Analyzing content...')).toBeInTheDocument();
+      });
+
+      capturedOnProgress!('Building flashcards...');
+
+      await waitFor(() => {
+        expect(screen.getByText('Building flashcards...')).toBeInTheDocument();
       });
     });
   });

--- a/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
@@ -4,13 +4,15 @@ import {
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
   Alert, Badge, Button, ModalDialog,
-  Stack,
+  Spinner, Stack,
 } from '@openedx/paragon';
+import { AutoAwesome } from '@openedx/paragon/icons';
 import Flashcard from './Flashcard';
 import StudyControls from './StudyControls';
 import { useStudySession } from '../hooks/useStudySession';
 import { calculateNextReview } from '../utils';
-import { saveCardStack, clearSession } from '../data/workflowActions';
+import { saveCardStack, clearSession, generateFlashcards } from '../data/workflowActions';
+import { POLLING_ERROR_KEYS, useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
 import { Flashcard as FlashcardType, CardStack } from '../types';
 import { prepareContextData } from '../../services';
 import LastReviewLabel from './LastReviewLabel';
@@ -47,6 +49,8 @@ const FlashcardStudyResponse = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFlipped, setIsFlipped] = useState(false);
   const [saveError, setSaveError] = useState('');
+  const [isAdding, setIsAdding] = useState(false);
+  const [addError, setAddError] = useState('');
   const isDirtyRef = useRef(false);
   const cardsRef = useRef(cards);
   // Re-parse cards when response changes and reopen the modal
@@ -66,6 +70,49 @@ const FlashcardStudyResponse = ({
 
   // Keep cardsRef in sync so the auto-save callback always has fresh data
   useEffect(() => { cardsRef.current = cards; }, [cards]);
+
+  // ── Add cards (run_async) ───────────────────────────────────────────────
+  const courseId = (contextData as any)?.courseId || '';
+
+  const onAddComplete = useCallback((responseData: any) => {
+    const newCards = parseCards(responseData);
+    if (newCards.length > 0) {
+      setCards((prev) => [...prev, ...newCards]);
+      isDirtyRef.current = true;
+    }
+    setIsAdding(false);
+  }, []);
+
+  const onAddError = useCallback((errorKey: string) => {
+    setIsAdding(false);
+    const key = errorKey === POLLING_ERROR_KEYS.TIMEOUT
+      ? 'ai.extensions.flashcard.error.timeout'
+      : 'ai.extensions.flashcard.error.generate';
+    setAddError(intl.formatMessage(messages[key]));
+  }, [intl]);
+
+  const { startPolling: startAddPolling, stopPolling: stopAddPolling } = useAsyncTaskPolling({
+    contextData: preparedContext,
+    courseId,
+    onComplete: onAddComplete,
+    onError: onAddError,
+  });
+
+  const handleAddCards = async () => {
+    setIsAdding(true);
+    setAddError('');
+    try {
+      const data = await generateFlashcards({ context: preparedContext, numCards: null });
+      if (data.taskId) {
+        startAddPolling(data.taskId);
+      } else {
+        onAddComplete(data);
+      }
+    } catch {
+      setIsAdding(false);
+      setAddError(intl.formatMessage(messages['ai.extensions.flashcard.error.generate']));
+    }
+  };
 
   const autoSave = useCallback(async () => {
     if (!isDirtyRef.current) { return; }
@@ -179,6 +226,19 @@ const FlashcardStudyResponse = ({
                 </>
               )}
             </Button>
+            <Button
+              size="sm"
+              variant="outline-primary"
+              iconBefore={isAdding ? undefined : AutoAwesome}
+              onClick={handleAddCards}
+              disabled={isAdding}
+            >
+              {isAdding ? (
+                <Spinner animation="border" size="sm" screenReaderText={intl.formatMessage(messages['ai.extensions.flashcard.generate.form.generating'])} />
+              ) : (
+                intl.formatMessage(messages['ai.extensions.flashcard.creator.add.cards.button'])
+              )}
+            </Button>
             <Button size="sm" variant="outline-primary" onClick={handleClearSession}>
               {intl.formatMessage(messages['ai.extensions.flashcard.study.clear.session'])}
             </Button>
@@ -253,6 +313,17 @@ const FlashcardStudyResponse = ({
           </ModalDialog.CloseButton>
         </ModalDialog.Footer>
       </ModalDialog>
+
+      {addError && (
+        <Alert
+          variant="danger"
+          dismissible
+          onClose={() => { setAddError(''); stopAddPolling(); }}
+          className="mt-3"
+        >
+          {addError}
+        </Alert>
+      )}
 
       {saveError && (
         <Alert

--- a/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
+++ b/frontend/src/flashcard-study/components/FlashcardStudyResponse.tsx
@@ -3,17 +3,17 @@ import {
 } from 'react';
 import { useIntl } from '@edx/frontend-platform/i18n';
 import {
-  Alert, Badge, Button, ModalDialog,
-  Spinner, Stack,
+  Alert, Badge, Button, Icon, ModalDialog,
+  Stack, StatefulButton,
 } from '@openedx/paragon';
-import { AutoAwesome } from '@openedx/paragon/icons';
+import { AutoAwesome, Quiz, SpinnerSimple } from '@openedx/paragon/icons';
 import Flashcard from './Flashcard';
 import StudyControls from './StudyControls';
 import { useStudySession } from '../hooks/useStudySession';
+import { useAsyncTaskPolling, POLLING_ERROR_KEYS } from '../hooks/useAsyncTaskPolling';
 import { calculateNextReview } from '../utils';
-import { saveCardStack, clearSession, generateFlashcards } from '../data/workflowActions';
-import { POLLING_ERROR_KEYS, useAsyncTaskPolling } from '../hooks/useAsyncTaskPolling';
-import { Flashcard as FlashcardType, CardStack } from '../types';
+import { saveCardStack, generateFlashcards } from '../data/workflowActions';
+import { Flashcard as FlashcardType, CardStack, FlashcardStep } from '../types';
 import { prepareContextData } from '../../services';
 import LastReviewLabel from './LastReviewLabel';
 import messages from '../messages';
@@ -22,7 +22,6 @@ export interface FlashcardStudyResponseProps {
   response: any;
   error?: string;
   isLoading?: boolean;
-  onClear: () => void;
   contextData?: Record<string, any>;
   customMessage?: string;
 }
@@ -35,11 +34,16 @@ const parseCards = (data: any): FlashcardType[] => {
   return [];
 };
 
+const ERROR_MESSAGES: Record<string, keyof typeof messages> = {
+  [POLLING_ERROR_KEYS.TIMEOUT]: 'ai.extensions.flashcard.error.timeout',
+  [POLLING_ERROR_KEYS.GENERATE]: 'ai.extensions.flashcard.error.generate',
+  [POLLING_ERROR_KEYS.NETWORK]: 'ai.extensions.flashcard.error.network',
+};
+
 const FlashcardStudyResponse = ({
   response,
   error,
   isLoading,
-  onClear,
   customMessage,
   contextData = {},
 }: FlashcardStudyResponseProps) => {
@@ -49,8 +53,9 @@ const FlashcardStudyResponse = ({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isFlipped, setIsFlipped] = useState(false);
   const [saveError, setSaveError] = useState('');
-  const [isAdding, setIsAdding] = useState(false);
-  const [addError, setAddError] = useState('');
+  const [step, setStep] = useState<FlashcardStep>('idle');
+  const [errorMessage, setErrorMessage] = useState('');
+  const [progressMessage, setProgressMessage] = useState('');
   const isDirtyRef = useRef(false);
   const cardsRef = useRef(cards);
   // Re-parse cards when response changes and reopen the modal
@@ -73,45 +78,57 @@ const FlashcardStudyResponse = ({
 
   // ── Add cards (run_async) ───────────────────────────────────────────────
   const courseId = (contextData as any)?.courseId || '';
-
+  const numCards = response?.numCards ?? null;
   const onAddComplete = useCallback((responseData: any) => {
     const newCards = parseCards(responseData);
     if (newCards.length > 0) {
       setCards((prev) => [...prev, ...newCards]);
       isDirtyRef.current = true;
     }
-    setIsAdding(false);
+    setStep('idle');
+    setProgressMessage('');
   }, []);
 
   const onAddError = useCallback((errorKey: string) => {
-    setIsAdding(false);
-    const key = errorKey === POLLING_ERROR_KEYS.TIMEOUT
-      ? 'ai.extensions.flashcard.error.timeout'
-      : 'ai.extensions.flashcard.error.generate';
-    setAddError(intl.formatMessage(messages[key]));
+    setStep('error');
+    setProgressMessage('');
+    const key = ERROR_MESSAGES[errorKey] || 'ai.extensions.flashcard.error.generate';
+    setErrorMessage(intl.formatMessage(messages[key]));
   }, [intl]);
 
-  const { startPolling: startAddPolling, stopPolling: stopAddPolling } = useAsyncTaskPolling({
+  const onAddProgress = useCallback((message: string) => {
+    setProgressMessage(message);
+  }, []);
+
+  const { startPolling: startAddPolling } = useAsyncTaskPolling({
     contextData: preparedContext,
     courseId,
     onComplete: onAddComplete,
     onError: onAddError,
+    onProgress: onAddProgress,
   });
 
   const handleAddCards = async () => {
-    setIsAdding(true);
-    setAddError('');
+    setStep('generating');
+    setErrorMessage('');
+    setProgressMessage('');
     try {
-      const data = await generateFlashcards({ context: preparedContext, numCards: null });
+      const data = await generateFlashcards({ context: preparedContext, numCards });
       if (data.taskId) {
         startAddPolling(data.taskId);
+        if (data.message) { setProgressMessage(data.message); }
       } else {
         onAddComplete(data);
       }
     } catch {
-      setIsAdding(false);
-      setAddError(intl.formatMessage(messages['ai.extensions.flashcard.error.generate']));
+      setStep('error');
+      setErrorMessage(intl.formatMessage(messages['ai.extensions.flashcard.error.generate']));
     }
+  };
+
+  const handleDismissError = () => {
+    setStep('idle');
+    setErrorMessage('');
   };
 
   const autoSave = useCallback(async () => {
@@ -177,15 +194,6 @@ const FlashcardStudyResponse = ({
     setIsModalOpen(true);
   };
 
-  const handleClearSession = async () => {
-    try {
-      await clearSession({ context: preparedContext });
-    } catch {
-      // Silently fail — still reset the UI
-    }
-    onClear();
-  };
-
   if (isLoading || (!response && !error)) { return null; }
 
   if (error) {
@@ -197,27 +205,14 @@ const FlashcardStudyResponse = ({
 
   return (
     <>
-      {!hasCards && (
-        <Alert
-          variant="info"
-          actions={[
-            <Button onClick={handleClearSession}>
-              {intl.formatMessage(messages['ai.extensions.flashcard.study.clear.session'])}
-            </Button>,
-          ]}
-        >
-          {intl.formatMessage(messages['ai.extensions.flashcard.study.empty'])}
-        </Alert>
-      )}
-
-      {hasCards && (
-        <div className="d-flex align items-center justify-content-between my-3 py-3 small border-bottom">
-          <div>
-            <span>{intl.formatMessage(messages['ai.extensions.flashcard.study.session.description'])}</span>
-            <LastReviewLabel cards={cards} />
-          </div>
-          <Stack gap={2} direction="horizontal">
-            <Button size="sm" onClick={handleReopen}>
+      <div className="d-flex align-items-center justify-content-end px-3 small flex-wrap">
+        <div className="my-2 mw-md-50">
+          <span className="pr-md-5">{intl.formatMessage(messages['ai.extensions.flashcard.study.session.description'])}</span>
+          <LastReviewLabel cards={cards} />
+        </div>
+        <Stack gap={2} direction="horizontal">
+          {hasCards && (
+            <Button size="sm" onClick={handleReopen} iconBefore={Quiz}>
               <span>{intl.formatMessage(messages['ai.extensions.flashcard.creator.display.button'])}</span>
               {dueCards.length > 0 && (
                 <>
@@ -226,25 +221,30 @@ const FlashcardStudyResponse = ({
                 </>
               )}
             </Button>
-            <Button
-              size="sm"
-              variant="outline-primary"
-              iconBefore={isAdding ? undefined : AutoAwesome}
-              onClick={handleAddCards}
-              disabled={isAdding}
-            >
-              {isAdding ? (
-                <Spinner animation="border" size="sm" screenReaderText={intl.formatMessage(messages['ai.extensions.flashcard.generate.form.generating'])} />
-              ) : (
-                intl.formatMessage(messages['ai.extensions.flashcard.creator.add.cards.button'])
-              )}
-            </Button>
-            <Button size="sm" variant="outline-primary" onClick={handleClearSession}>
-              {intl.formatMessage(messages['ai.extensions.flashcard.study.clear.session'])}
-            </Button>
-          </Stack>
-        </div>
-      )}
+          )}
+          <StatefulButton
+            variant="outline-primary"
+            size="sm"
+            onClick={handleAddCards}
+            state={step}
+            labels={{
+              idle: intl.formatMessage(messages['ai.extensions.flashcard.study.clear.session']),
+              loading: intl.formatMessage(messages['ai.extensions.flashcard.creator.loading']),
+              generating: progressMessage || intl.formatMessage(messages['ai.extensions.flashcard.generating']),
+            }}
+            icons={{
+              idle: <Icon src={AutoAwesome} />,
+              generating: <Icon src={SpinnerSimple} className="icon-spin" />,
+            }}
+            disabledStates={['loading', 'generating']}
+          />
+        </Stack>
+        {step === 'error' && errorMessage && (
+          <Alert variant="danger" dismissible onClose={handleDismissError} className="mt-3">
+            {errorMessage}
+          </Alert>
+        )}
+      </div>
 
       <ModalDialog
         title={customMessage || intl.formatMessage(messages['ai.extensions.flashcard.title'])}
@@ -313,17 +313,6 @@ const FlashcardStudyResponse = ({
           </ModalDialog.CloseButton>
         </ModalDialog.Footer>
       </ModalDialog>
-
-      {addError && (
-        <Alert
-          variant="danger"
-          dismissible
-          onClose={() => { setAddError(''); stopAddPolling(); }}
-          className="mt-3"
-        >
-          {addError}
-        </Alert>
-      )}
 
       {saveError && (
         <Alert

--- a/frontend/src/flashcard-study/components/GenerateForm.tsx
+++ b/frontend/src/flashcard-study/components/GenerateForm.tsx
@@ -31,9 +31,9 @@ const GenerateForm = ({ onGenerate, isLoading }: GenerateFormProps) => {
 
   return (
 
-    <Container className="d-flex justify-content-between align-items-center flex-wrap">
-      <span className="small">{intl.formatMessage(messages['ai.extensions.flashcard.generate.form.auto.help'])}</span>
-      <ButtonGroup size="sm" className="w-sm-100 w-md-50">
+    <Container className="d-flex align-items-center justify-content-end px-3 small flex-wrap">
+      <span className="d-block my-2 pr-md-5 container-mw-xs">{intl.formatMessage(messages['ai.extensions.flashcard.generate.form.auto.help'])}</span>
+      <ButtonGroup size="sm" className="w-sm-100 w-md-25">
         {DEPTH_OPTIONS.map(({
           value, numCards, sublabelKey, icon,
         }) => (
@@ -44,14 +44,14 @@ const GenerateForm = ({ onGenerate, isLoading }: GenerateFormProps) => {
             onClick={() => onGenerate(numCards)}
             disabled={isLoading}
           >
-            <div className="d-flex flex-column">
+            <div className="d-flex flex-column x-small">
 
               <strong>
                 {numCards === null
                   ? intl.formatMessage(messages['ai.extensions.flashcard.generate.depth.auto'])
                   : intl.formatMessage(messages['ai.extensions.flashcard.generate.depth.cards'], { count: numCards })}
               </strong>
-              <small className="x-small">{intl.formatMessage(messages[sublabelKey])}</small>
+              <span>{intl.formatMessage(messages[sublabelKey])}</span>
             </div>
           </Button>
         ))}

--- a/frontend/src/flashcard-study/hooks/useAsyncTaskPolling.ts
+++ b/frontend/src/flashcard-study/hooks/useAsyncTaskPolling.ts
@@ -17,6 +17,7 @@ interface UseAsyncTaskPollingOptions {
   courseId: string;
   onComplete: (responseData: any) => void;
   onError: (errorKey: string, detail?: string) => void;
+  onProgress?: (message: string) => void;
 }
 
 /**
@@ -32,6 +33,7 @@ interface UseAsyncTaskPollingOptions {
  * @param options.courseId    - Course identifier forwarded to the poll request.
  * @param options.onComplete  - Called with the response payload when the task succeeds.
  * @param options.onError     - Called with `'timeout'`, `'generate'`, or `'network'` and an optional detail.
+ * @param options.onProgress  - Called with the backend message on each in-progress poll response.
  * @returns startPolling - Begins polling for the given `taskId`.
  * @returns stopPolling  - Cancels any active polling interval.
  */
@@ -40,6 +42,7 @@ export const useAsyncTaskPolling = ({
   courseId,
   onComplete,
   onError,
+  onProgress,
 }: UseAsyncTaskPollingOptions) => {
   const pollingIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const pollingStartTimeRef = useRef<number | null>(null);
@@ -61,13 +64,15 @@ export const useAsyncTaskPolling = ({
       } else if (data.status === 'error' || data.status === 'timeout' || data.error) {
         stopPolling();
         onError(POLLING_ERROR_KEYS.GENERATE, data.error || data.message);
+      } else if (data.message && onProgress) {
+        onProgress(data.message);
       }
     } catch (err) {
       logError('useAsyncTaskPolling: poll error:', err);
       stopPolling();
       onError(POLLING_ERROR_KEYS.NETWORK, (err as Error).message);
     }
-  }, [contextData, courseId, onComplete, onError, stopPolling]);
+  }, [contextData, courseId, onComplete, onError, onProgress, stopPolling]);
 
   const startPolling = useCallback((taskId: string) => {
     pollingStartTimeRef.current = Date.now();

--- a/frontend/src/flashcard-study/messages.ts
+++ b/frontend/src/flashcard-study/messages.ts
@@ -91,8 +91,8 @@ const messages = defineMessages({
     defaultMessage: 'Deep',
     description: 'Sublabel for the deep depth option',
   },
-  'ai.extensions.flashcard.generate.form.generating': {
-    id: 'ai.extensions.flashcard.generate.form.generating',
+  'ai.extensions.flashcard.generating': {
+    id: 'ai.extensions.flashcard.generating',
     defaultMessage: 'Generating',
     description: 'Submit button label while generation is in progress',
   },
@@ -151,11 +151,6 @@ const messages = defineMessages({
     defaultMessage: 'Done',
     description: 'Button to close the study modal and return to the request component',
   },
-  'ai.extensions.flashcard.study.empty': {
-    id: 'ai.extensions.flashcard.study.empty',
-    defaultMessage: 'No flashcards found. Generate some cards first.',
-    description: 'Message shown when the response contains no cards',
-  },
   'ai.extensions.flashcard.error.save': {
     id: 'ai.extensions.flashcard.error.save',
     defaultMessage: 'Failed to save progress.',
@@ -168,7 +163,7 @@ const messages = defineMessages({
   },
   'ai.extensions.flashcard.study.session.description': {
     id: 'ai.extensions.flashcard.study.session.description',
-    defaultMessage: 'Use your flashcards to review the unit content.',
+    defaultMessage: 'Use your flashcards to review the course content.',
     description: 'Message shown when a preloaded session has cards available',
   },
   'ai.extensions.flashcard.study.paused.session.justNow': {
@@ -183,13 +178,8 @@ const messages = defineMessages({
   },
   'ai.extensions.flashcard.study.clear.session': {
     id: 'ai.extensions.flashcard.study.clear.session',
-    defaultMessage: 'Generate New Set',
-    description: 'Button to clear the current session and generate a new card deck',
-  },
-  'ai.extensions.flashcard.creator.add.cards.button': {
-    id: 'ai.extensions.flashcard.creator.add.cards.button',
-    defaultMessage: 'Add cards',
-    description: 'Button to directly generate and add flashcards via run_async',
+    defaultMessage: 'Generate Unit Cards',
+    description: 'Generate cards for the current unit and add it to the course deck',
   },
 });
 

--- a/frontend/src/flashcard-study/messages.ts
+++ b/frontend/src/flashcard-study/messages.ts
@@ -186,6 +186,11 @@ const messages = defineMessages({
     defaultMessage: 'Generate New Set',
     description: 'Button to clear the current session and generate a new card deck',
   },
+  'ai.extensions.flashcard.creator.add.cards.button': {
+    id: 'ai.extensions.flashcard.creator.add.cards.button',
+    defaultMessage: 'Add cards',
+    description: 'Button to directly generate and add flashcards via run_async',
+  },
 });
 
 export default messages;


### PR DESCRIPTION
This pull request introduces significant improvements to the flashcard generation workflow, focusing on enhancing session management, card enrichment, and frontend user experience. The backend now uses a course-scoped session for flashcards, ensures consistent card formatting and metadata enrichment, and improves handling of existing cards to avoid duplicates. The frontend adds the ability for users to generate additional flashcards during a study session, with robust error handling and UI feedback. Tests have been updated to reflect the new response structures and behaviors.

**Backend: Flashcard Workflow and Session Management**

* Introduced `ScopedSessionOrchestrator` to enable scoped (rather than location-specific) sessions for flashcards, ensuring card continuity across locations. (`flashcards_orchestrator.py`, `session_based_orchestrator.py`) [[1]](diffhunk://#diff-3730d5b060dfedd6e72bd3174c18db8af572830cd97e8133d7c4acdf7b7f8681L11-R14) [[2]](diffhunk://#diff-19950372b5e5a676f7736d1b7e86cc193458e15939ab23610592659764c99a1cR210-R228)
* Refactored card enrichment logic: added `_get_structured_cards` helper to consistently enrich cards with spaced repetition metadata and handle various response formats. (`flashcards_orchestrator.py`) [[1]](diffhunk://#diff-3730d5b060dfedd6e72bd3174c18db8af572830cd97e8133d7c4acdf7b7f8681R29-R62) [[2]](diffhunk://#diff-3730d5b060dfedd6e72bd3174c18db8af572830cd97e8133d7c4acdf7b7f8681L76-R127)
* Enhanced flashcard generation to include existing cards in the prompt, preventing duplicate questions. (`flashcards_orchestrator.py`, `default_generate_flashcards.txt`) [[1]](diffhunk://#diff-3730d5b060dfedd6e72bd3174c18db8af572830cd97e8133d7c4acdf7b7f8681R84-R103) [[2]](diffhunk://#diff-85cb6ef236b4def53e46cf7cbf761bf6643ce2e7da2947b21f3982f692a8bc5dR21-R23)
* Improved session metadata updates and card saving logic, with clearer status and message feedback. (`flashcards_orchestrator.py`)
* Updated session response structure to always return a status and cards, improving API consistency. (`flashcards_orchestrator.py`)

**Frontend: Flashcard Study Experience**

* Added "Add More Cards" functionality, allowing users to generate additional flashcards mid-session, with loading indicators and error handling. (`FlashcardStudyResponse.tsx`) [[1]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322L7-R15) [[2]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322R52-R53) [[3]](diffhunk://#diff-6d97e0a0d628930e0a3d2f75cce92020cba49e57d9686a3b38c19f66b1997322R74-R116)

**Testing: Adjustments for New Behaviors**

* Updated tests to expect new response structures (status and cards) and to check for card enrichment and error handling. (`test_flashcards_orchestrator.py`) [[1]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL91-R91) [[2]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL104-R104) [[3]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL117-R117) [[4]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL216-R217) [[5]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL441-R442) [[6]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL458-R460) [[7]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL477-R479) [[8]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL512-R515) [[9]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL536-R538) [[10]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL556-R558) [[11]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL575-R577) [[12]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL592-R595) [[13]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL648-R651) [[14]](diffhunk://#diff-b2f4916df2f60c02320787b8f072f078428aaa4ee31cea04c6b90fabf78df5ffL698-R702)