### PR TITLE
feat!: use attempts instead of manually leave subsequent submissions

### DIFF
--- a/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/submission_processor.py
@@ -65,25 +65,16 @@ class SubmissionProcessor:
         for submission in reversed(submissions):
             submission_messages = json.loads(submission["answer"])
             timestamp = str(submission.get("created_at") or submission.get("submitted_at") or "")
-            # Remove metadata if present
             if submission_messages and isinstance(submission_messages, list):
-                submission_messages_copy = submission_messages.copy()
-                if (
-                    submission_messages_copy
-                    and isinstance(submission_messages_copy[-1], dict)
-                    and submission_messages_copy[-1].get("_metadata")
-                ):
-                    submission_messages_copy.pop()
                 # Remove system messages if present
                 submission_messages_copy = [
-                    msg for msg in submission_messages_copy if msg.get("role") != "system"
+                    msg for msg in submission_messages if isinstance(msg, dict) and msg.get("role") != "system"
                 ]
                 submission_uuid = submission.get("uuid", "")
                 for msg in submission_messages_copy:
-                    if isinstance(msg, dict):
-                        msg["timestamp"] = timestamp
-                        if include_submission_id:
-                            msg["submission_id"] = submission_uuid
+                    msg["timestamp"] = timestamp
+                    if include_submission_id:
+                        msg["submission_id"] = submission_uuid
                 # Extend to maintain chronological order (oldest to newest)
                 all_messages.extend(submission_messages_copy)
 
@@ -196,57 +187,24 @@ class SubmissionProcessor:
 
     def update_chat_submission(self, messages):
         """
-        Update the submission with the LLM response.
-        Truncates message history to keep only the most recent messages while
-        preserving references to previous submission IDs.
+        Create a new immutable Submission record for this interaction.
+
+        Each call stores the provided messages (prompt + AI response) as a new
+        Submission.  History is tracked implicitly via ``attempt_number``, which
+        the Submissions API auto-increments for the same ``student_item``.
         """
-
-        previous_submission_ids = []
-
-        if self.user_session.local_submission_id:
-            submission = submissions_api.get_submission_and_student(
-                self.user_session.local_submission_id
-            )
-
-            # Store current submission ID as previous
-            previous_submission_ids.append(self.user_session.local_submission_id)
-
-            # Get existing messages and any previously tracked submission IDs
-            existing_messages = submission["answer"]
-
-            # Extract metadata if it exists (for tracking previous submission IDs)
-            if existing_messages and isinstance(existing_messages, list):
-                # Check if the last item is metadata
-                if (
-                    existing_messages
-                    and isinstance(existing_messages[-1], dict)
-                    and existing_messages[-1].get("_metadata")
-                ):
-                    metadata = existing_messages.pop()
-                    previous_submission_ids = (
-                        metadata.get("previous_submission_ids", [])
-                        + previous_submission_ids
-                    )
-
-        # Add metadata to track previous submission IDs
-        if previous_submission_ids:
-            messages.append(
-                {
-                    "_metadata": True,
-                    "previous_submission_ids": previous_submission_ids,
-                }
-            )
-
         self.update_submission(messages)
 
     def update_submission(self, data):
         """
-        Update the submission with provided data.
+        Create a new Submission record with the provided data.
+
+        ``attempt_number`` is intentionally omitted so the Submissions API
+        auto-increments it for the given ``student_item``.
         """
         submission = submissions_api.create_submission(
             student_item_dict=self.student_item_dict,
             answer=json.dumps(data),
-            attempt_number=1,
         )
         self.user_session.local_submission_id = submission["uuid"]
         self.user_session.save()

--- a/backend/tests/test_submission_processor.py
+++ b/backend/tests/test_submission_processor.py
@@ -546,9 +546,11 @@ def test_update_chat_submission_creates_new_submission(
     mock_submissions_api.create_submission.assert_called_once()
     call_args = mock_submissions_api.create_submission.call_args
     assert call_args[1]["student_item_dict"] == processor.student_item_dict
-    assert call_args[1]["attempt_number"] == 1
 
-    # Verify answer contains the messages
+    # attempt_number should NOT be passed (auto-incremented by the API)
+    assert "attempt_number" not in call_args[1]
+
+    # Verify answer contains the messages without metadata
     answer = json.loads(call_args[1]["answer"])
     assert len(answer) == 2
     assert answer[0]["role"] == "user"
@@ -561,23 +563,13 @@ def test_update_chat_submission_creates_new_submission(
 
 @pytest.mark.django_db
 @patch("openedx_ai_extensions.processors.openedx.submission_processor.submissions_api")
-def test_update_chat_submission_tracks_previous_submissions(
+def test_update_chat_submission_does_not_track_previous_ids(
     mock_submissions_api, submission_processor  # pylint: disable=redefined-outer-name
 ):
     """
-    Test that update_chat_submission tracks previous submission IDs.
+    Test that update_chat_submission does NOT embed previous_submission_ids
+    metadata.  History is now tracked via attempt_number.
     """
-    # Mock existing submission with messages
-    existing_messages = [
-        {"role": "user", "content": "Old message"},
-        {"role": "assistant", "content": "Old response"}
-    ]
-
-    mock_submissions_api.get_submission_and_student.return_value = {
-        "uuid": "test-submission-uuid-123",
-        "answer": existing_messages
-    }
-
     mock_submissions_api.create_submission.return_value = {"uuid": "new-submission-uuid"}
 
     new_messages = [
@@ -587,65 +579,15 @@ def test_update_chat_submission_tracks_previous_submissions(
 
     submission_processor.update_chat_submission(new_messages)
 
-    # Verify create_submission was called
     call_args = mock_submissions_api.create_submission.call_args
     answer = json.loads(call_args[1]["answer"])
 
-    # Should contain messages and metadata
-    assert len(answer) == 3  # 2 messages + 1 metadata
-    assert answer[0]["role"] == "user"
-    assert answer[1]["role"] == "assistant"
+    # Should contain only the two messages — no _metadata entry
+    assert len(answer) == 2
+    assert all("_metadata" not in msg for msg in answer)
 
-    # Check metadata tracks previous submission
-    metadata = answer[2]
-    assert metadata.get("_metadata") is True
-    assert "test-submission-uuid-123" in metadata["previous_submission_ids"]
-
-
-@pytest.mark.django_db
-@patch("openedx_ai_extensions.processors.openedx.submission_processor.submissions_api")
-def test_update_chat_submission_preserves_previous_submission_chain(
-    mock_submissions_api, submission_processor  # pylint: disable=redefined-outer-name
-):
-    """
-    Test that update_chat_submission preserves chain of previous submission IDs.
-    """
-    # Mock existing submission that already has metadata
-    existing_messages = [
-        {"role": "user", "content": "Message"},
-        {"role": "assistant", "content": "Response"},
-        {
-            "_metadata": True,
-            "previous_submission_ids": ["oldest-submission-uuid", "older-submission-uuid"]
-        }
-    ]
-
-    mock_submissions_api.get_submission_and_student.return_value = {
-        "uuid": "test-submission-uuid-123",
-        "answer": existing_messages
-    }
-
-    mock_submissions_api.create_submission.return_value = {"uuid": "newest-submission-uuid"}
-
-    new_messages = [
-        {"role": "user", "content": "New message"},
-        {"role": "assistant", "content": "New response"}
-    ]
-
-    submission_processor.update_chat_submission(new_messages)
-
-    # Verify create_submission was called
-    call_args = mock_submissions_api.create_submission.call_args
-    answer = json.loads(call_args[1]["answer"])
-
-    # Check metadata preserves the chain
-    metadata = answer[-1]
-    assert metadata.get("_metadata") is True
-    assert "oldest-submission-uuid" in metadata["previous_submission_ids"]
-    assert "older-submission-uuid" in metadata["previous_submission_ids"]
-    assert "test-submission-uuid-123" in metadata["previous_submission_ids"]
-    # Should have 3 previous submission IDs in the chain
-    assert len(metadata["previous_submission_ids"]) == 3
+    # get_submission_and_student should NOT have been called
+    mock_submissions_api.get_submission_and_student.assert_not_called()
 
 
 # ============================================================================
@@ -670,7 +612,6 @@ def test_update_submission_creates_submission(
     mock_submissions_api.create_submission.assert_called_once_with(
         student_item_dict=submission_processor.student_item_dict,
         answer=json.dumps(data),
-        attempt_number=1
     )
 
     # Verify session was updated with new submission ID


### PR DESCRIPTION
This pull request refactors how chat submissions are stored and tracked in the Open edX AI extensions. The main change is to simplify submission history tracking: instead of embedding metadata about previous submission IDs in each submission, the system now relies on the Submissions API's built-in `attempt_number` for implicit history tracking. The code and tests are updated to reflect this new, more streamlined approach.

Key changes include:

**Submission Processing Logic:**
* Refactored `update_chat_submission` and `update_submission` methods in `submission_processor.py` to eliminate embedding of `_metadata` and `previous_submission_ids` in submission messages. Now, each submission is a new immutable record, and history is tracked via the auto-incremented `attempt_number` field managed by the Submissions API. (`[backend/openedx_ai_extensions/processors/openedx/submission_processor.pyL199-L249](diffhunk://#diff-c53b90d286b47113ebedd397d5c0af053205d229428d5d88591057ce5533694aL199-L249)`)
* Removed logic that attempted to strip metadata from message lists during message processing, as metadata is no longer present. (`[backend/openedx_ai_extensions/processors/openedx/submission_processor.pyL68-L83](diffhunk://#diff-c53b90d286b47113ebedd397d5c0af053205d229428d5d88591057ce5533694aL68-L83)`)

**Testing Updates:**
* Updated tests to ensure that `attempt_number` is no longer passed to `create_submission`, and that no `_metadata` is embedded in the stored messages. (`[[1]](diffhunk://#diff-e8ca570bc720c4e957dfbc6aa8a57619f1799ffc13d9f0d842c47926f9dbf921L549-R553)`, `[[2]](diffhunk://#diff-e8ca570bc720c4e957dfbc6aa8a57619f1799ffc13d9f0d842c47926f9dbf921L673)`)
* Replaced and removed tests that previously checked for metadata tracking of previous submission IDs. New tests confirm that previous submission IDs are not tracked in metadata, and that the API's `get_submission_and_student` method is no longer called during updates. (`[[1]](diffhunk://#diff-e8ca570bc720c4e957dfbc6aa8a57619f1799ffc13d9f0d842c47926f9dbf921L564-L580)`, `[[2]](diffhunk://#diff-e8ca570bc720c4e957dfbc6aa8a57619f1799ffc13d9f0d842c47926f9dbf921L590-R590)`)