### PR TITLE
fix: removing cache for the get_profiles function

### DIFF
--- a/backend/openedx_ai_extensions/workflows/models.py
+++ b/backend/openedx_ai_extensions/workflows/models.py
@@ -247,7 +247,6 @@ class AIWorkflowScope(models.Model):
         self._action = value
 
     @classmethod
-    @functools.lru_cache(maxsize=128)
     def get_profile(cls, course_id=None, location_id=None, ui_slot_selector_id=None):
         """
         Resolve the best-matching AIWorkflowScope for the given context.
@@ -583,16 +582,3 @@ class AIWorkflowSession(models.Model):
             combined.insert(insert_at, entry)
 
         return combined
-
-
-# Signal handlers for cache invalidation
-@receiver(post_save, sender=AIWorkflowScope)
-@receiver(post_delete, sender=AIWorkflowScope)
-@receiver(post_save, sender=AIWorkflowProfile)
-@receiver(post_delete, sender=AIWorkflowProfile)
-def clear_workflow_cache(**kwargs):
-    """
-    Clear get_profile LRU cache when AIWorkflowScope or AIWorkflowProfile objects change.
-    This ensures the cache stays fresh when workflow configurations are modified.
-    """
-    AIWorkflowScope.get_profile.cache_clear()

--- a/backend/openedx_ai_extensions/workflows/models.py
+++ b/backend/openedx_ai_extensions/workflows/models.py
@@ -1,7 +1,6 @@
 """
 AI Workflow models for managing flexible AI workflow execution
 """
-import functools
 import logging
 import re
 from typing import Any, Optional
@@ -12,8 +11,6 @@ from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import Q
-from django.db.models.signals import post_delete, post_save
-from django.dispatch import receiver
 from django.utils.functional import cached_property
 from opaque_keys.edx.django.models import CourseKeyField, UsageKeyField
 

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -716,9 +716,7 @@ class TestAIWorkflowScopeResolution:
         )
 
         resolved_a = AIWorkflowScope.get_profile(course_key, location_id, ui_slot_selector_id="widget-a")
-        AIWorkflowScope.get_profile.cache_clear()
         resolved_b = AIWorkflowScope.get_profile(course_key, location_id, ui_slot_selector_id="widget-b")
-        AIWorkflowScope.get_profile.cache_clear()
         resolved_c = AIWorkflowScope.get_profile(course_key, location_id, ui_slot_selector_id="widget-c")
 
         assert resolved_a is not None and resolved_a.profile.slug == "profile-widget-a"


### PR DESCRIPTION
This PR just removes the LRU cache that we left at the get profile function.

We probably optimized before this was a limitation, but right now is creating havoc for development purposes and even for testing in in the sandbox where the authors are not completely sure which profile and scope they want to use. We want to be able to rapidly swap, and the function we had before that breaks the cache did not seem to be working.