### PR TITLE
fix: text area focus when the chat answers

### DIFF
--- a/frontend/src/components/AISidebarResponse.tsx
+++ b/frontend/src/components/AISidebarResponse.tsx
@@ -546,6 +546,7 @@ const AISidebarResponse = ({
       }]);
     } finally {
       setIsSendingFollowUp(false);
+      textareaRef.current?.focus();
     }
   };
 


### PR DESCRIPTION
This is a very simple PR to return the focus to the text box when a user submits the message and then the AI answers.

before: The focus would go to the gear at the top.
after: the focus remains in the textarea.