### PR TITLE
fix: focus ring no longer breaks layout

### DIFF
--- a/frontend/src/components/AISidebarResponse.tsx
+++ b/frontend/src/components/AISidebarResponse.tsx
@@ -748,15 +748,17 @@ const AISidebarResponse = ({
               className="ai-sidebar-chat-input"
             />
             {/* Send button positioned inside textarea */}
-            <Button
-              size="sm"
-              className="ai-sidebar-chat-button zindex-1"
-              onClick={handleFollowUpSubmit}
-              disabled={isLoading || isSendingFollowUp || !followUpQuestion.trim()}
-              aria-label={intl.formatMessage(messages['ai.extensions.sidebar.send.label'])}
-            >
-              <Icon src={Send} aria-hidden="true" size="xs" />
-            </Button>
+            <div className="ai-sidebar-chat-button-wrapper">
+              <Button
+                size="sm"
+                className="ai-sidebar-chat-button zindex-1"
+                onClick={handleFollowUpSubmit}
+                disabled={isLoading || isSendingFollowUp || !followUpQuestion.trim()}
+                aria-label={intl.formatMessage(messages['ai.extensions.sidebar.send.label'])}
+              >
+                <Icon src={Send} aria-hidden="true" size="xs" />
+              </Button>
+            </div>
           </div>
         )}
       </div>

--- a/frontend/src/components/sidebar.scss
+++ b/frontend/src/components/sidebar.scss
@@ -8,11 +8,15 @@
     }
 }
 
+.ai-sidebar-chat-button-wrapper {
+    position: absolute;
+    right: calc(1.5rem - 4px);
+    bottom: calc(1.5rem - 4px);
+    padding: 4px;
+}
+
 .ai-sidebar-chat-button {
     width: fit-content;
-    position: absolute;
-    right: 1.5rem;
-    bottom: 1.5rem;
 }
 
 .ai-sidebar-chat-input textarea {


### PR DESCRIPTION
This PR wraps the submission button for the messages in an empty div that will hold the absolute positioning.

With this the focus of the button no longer breaks the layout.

Now:
<img width="947" height="810" alt="image" src="https://github.com/user-attachments/assets/ccc63159-ed3c-480a-85dd-264991c78496" />

before:
<img width="947" height="810" alt="image" src="https://github.com/user-attachments/assets/1fb932e0-8297-4bb4-befe-1ec357bf9338" />

