### PR TITLE
fix: typo in fixtures

### DIFF
--- a/backend/openedx_ai_extensions/fixtures/demo_profiles.json
+++ b/backend/openedx_ai_extensions/fixtures/demo_profiles.json
@@ -15,7 +15,7 @@
     "fields": {
       "slug": "demo-flashcards",
       "description": "Flashcards profile for demo course. Generates flashcards from unit content.",
-      "base_filepath": "experimental/fashcards.json",
+      "base_filepath": "experimental/flashcards.json",
       "content_patch": "{\n  // -----------------------------------------------\n  // Flashcards demo profile\n  // Generates flashcards from the current unit content.\n  // Uses the provider configured in AI_EXTENSIONS settings.\n  // To override per-profile, uncomment the options block below.\n  // -----------------------------------------------\n  // \"processor_config\": {\n  //   \"LLMProcessor\": {\n  //     \"options\": {\n  //       \"API_KEY\": \"your-api-key-here\",\n  //     },\n  //   },\n  // },\n}"
     }
   },


### PR DESCRIPTION
This pull request includes a minor fix to the demo profiles fixture file, correcting a typo in the `base_filepath` field for the flashcards demo profile.

* Fixed typo in the `base_filepath` field from `"experimental/fashcards.json"` to `"experimental/flashcards.json"` in `demo_profiles.json` to ensure the correct file is referenced.