### PR TITLE
feat: add event consumer to allow run scopes

### DIFF
--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -35,6 +35,7 @@ class OpenedxAIExtensionsConfig(AppConfig):
         # Import the transformers module to trigger the @register decorators
         # Import the tasks module to trigger the registration
         from openedx_ai_extensions import tasks  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
+        import openedx_ai_extensions.receivers  # noqa: F401
         from openedx_ai_extensions.xapi import \
             transformers  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
 

--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -35,7 +35,7 @@ class OpenedxAIExtensionsConfig(AppConfig):
         # Import the transformers module to trigger the @register decorators
         # Import the tasks module to trigger the registration
         from openedx_ai_extensions import tasks  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
-        import openedx_ai_extensions.receivers  # noqa: F401
+        import openedx_ai_extensions.receivers  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
         from openedx_ai_extensions.xapi import \
             transformers  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
 

--- a/backend/openedx_ai_extensions/apps.py
+++ b/backend/openedx_ai_extensions/apps.py
@@ -34,8 +34,8 @@ class OpenedxAIExtensionsConfig(AppConfig):
         """
         # Import the transformers module to trigger the @register decorators
         # Import the tasks module to trigger the registration
-        from openedx_ai_extensions import tasks  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
         import openedx_ai_extensions.receivers  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
+        from openedx_ai_extensions import tasks  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
         from openedx_ai_extensions.xapi import \
             transformers  # noqa: F401 pylint: disable=unused-import,import-outside-toplevel
 

--- a/backend/openedx_ai_extensions/events/data.py
+++ b/backend/openedx_ai_extensions/events/data.py
@@ -1,0 +1,19 @@
+"""
+Attr data classes for AI Extensions events.
+These are owned by openedx-ai-extensions and imported by any app that
+wants to request an AI orchestration run.
+"""
+import attr
+
+
+@attr.s(frozen=True)
+class AIOrchestrationRequestData:
+    """
+    Payload for requesting an AI workflow run via the event bus.
+    """
+    user_id = attr.ib(type=int)
+    course_id = attr.ib(type=str, default=None)
+    location_id = attr.ib(type=str, default=None)
+    ui_slot_selector_id = attr.ib(type=str, default=None)
+    user_input = attr.ib(type=dict, default={})
+    action = attr.ib(type=str, default="run")

--- a/backend/openedx_ai_extensions/events/data.py
+++ b/backend/openedx_ai_extensions/events/data.py
@@ -15,5 +15,5 @@ class AIOrchestrationRequestData:
     course_id = attr.ib(type=str, default=None)
     location_id = attr.ib(type=str, default=None)
     ui_slot_selector_id = attr.ib(type=str, default=None)
-    user_input = attr.ib(type=dict, default={})
+    user_input = attr.ib(type=dict, factory=dict)
     action = attr.ib(type=str, default="run")

--- a/backend/openedx_ai_extensions/events/signals.py
+++ b/backend/openedx_ai_extensions/events/signals.py
@@ -1,0 +1,17 @@
+"""
+Public OpenEdxPublicSignal owned by openedx-ai-extensions.
+
+External apps import this signal to request an AI workflow run.
+openedx-ai-extensions is the sole consumer.
+"""
+from openedx_events.tooling import OpenEdxPublicSignal
+
+from openedx_ai_extensions.events.data import AIOrchestrationRequestData
+
+
+AI_ORCHESTRATION_REQUESTED = OpenEdxPublicSignal(
+    event_type="org.openedx.ai_extensions.orchestration.requested.v1",
+    data={
+        "ai_orchestration_request": AIOrchestrationRequestData,
+    }
+)

--- a/backend/openedx_ai_extensions/events/signals.py
+++ b/backend/openedx_ai_extensions/events/signals.py
@@ -8,7 +8,6 @@ from openedx_events.tooling import OpenEdxPublicSignal
 
 from openedx_ai_extensions.events.data import AIOrchestrationRequestData
 
-
 AI_ORCHESTRATION_REQUESTED = OpenEdxPublicSignal(
     event_type="org.openedx.ai_extensions.orchestration.requested.v1",
     data={

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -3,7 +3,6 @@ Django signal receivers for openedx-ai-extensions.
 This is the entry point that bridges the event bus → orchestrator.
 """
 import logging
-import profile
 
 from django.dispatch import receiver
 

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -26,16 +26,15 @@ def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs
 
     # Run the orchestrator with the provided input data
     try:
-        user = User.objects.get(id=ai_orchestration_request.user_id) if ai_orchestration_request.user_id else None
-        context = {
-            k: v
-            for k, v in {
-                "course_id": ai_orchestration_request.course_id if ai_orchestration_request.course_id else None,
-                "location_id": ai_orchestration_request.location_id if ai_orchestration_request.location_id else None,
-                "ui_slot_selector_id": ai_orchestration_request.ui_slot_selector_id,
-            }.items()
-            if v is not None
-        }
+        user = User.objects.get(id=ai_orchestration_request.user_id)
+        def compact(d: dict) -> dict:
+            return {k: v for k, v in d.items() if v is not None}
+
+        context = compact({
+            "course_id": ai_orchestration_request.course_id,
+            "location_id": ai_orchestration_request.location_id,
+            "ui_slot_selector_id": ai_orchestration_request.ui_slot_selector_id,
+        })
 
         workflow = AIWorkflowScope.get_profile(**context)
         if workflow is None:
@@ -44,13 +43,12 @@ def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs
                 context,
             )
             return
-        log.info("Found workflow profile for orchestration request. Context: %s", context)
-        result = workflow.execute(
+        workflow.execute(
             user_input=ai_orchestration_request.user_input,
             action=ai_orchestration_request.action,
             user=user,
             running_context=context,
         )
-        log.info("Successfully ran orchestrator for workflow. Context: %s", context)
     except Exception:
         log.exception("Error running orchestrator for workflow")
+        raise

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -1,32 +1,33 @@
 """
 Django signal receivers for openedx-ai-extensions.
+
 This is the entry point that bridges the event bus → orchestrator.
 """
 import logging
 
+from django.contrib.auth import get_user_model
 from django.dispatch import receiver
 
 from openedx_ai_extensions.events.signals import AI_ORCHESTRATION_REQUESTED
+from openedx_ai_extensions.workflows.models import AIWorkflowScope
 
 log = logging.getLogger(__name__)
 
 
 @receiver(AI_ORCHESTRATION_REQUESTED)
-def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs):
+def handle_ai_orchestration_requested(_sender, ai_orchestration_request, **kwargs):
     """
-    Triggered when any app publishes AI_ORCHESTRATION_REQUESTED, either
-    in-process (direct Django signal) or via the event bus consumer loop.
+    Triggered when any app publishes AI_ORCHESTRATION_REQUESTED.
 
+    Either in-process (direct Django signal) or via the event bus consumer loop.
     Looks up the AIWorkflowProfile by slug and runs the orchestrator.
     """
-    from openedx_ai_extensions.workflows.models import AIWorkflowScope
-    from django.contrib.auth import get_user_model
-
     User = get_user_model()
 
     # Run the orchestrator with the provided input data
     try:
         user = User.objects.get(id=ai_orchestration_request.user_id)
+
         def compact(d: dict) -> dict:
             return {k: v for k, v in d.items() if v is not None}
 

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @receiver(AI_ORCHESTRATION_REQUESTED)
-def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs):  # pylint: disable=unused-argument
+def handle_ai_orchestration_requested(_sender, ai_orchestration_request, **kwargs):
     """
     Triggered when any app publishes AI_ORCHESTRATION_REQUESTED.
 
@@ -40,7 +40,7 @@ def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs
         workflow = AIWorkflowScope.get_profile(**context)
         if workflow is None:
             log.error(
-                "TEST No workflow profile found for orchestration request. Context: %s",
+                "No workflow profile found for orchestration request. Context: %s",
                 context,
             )
             return

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -38,6 +38,12 @@ def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs
         }
 
         workflow = AIWorkflowScope.get_profile(**context)
+        if workflow is None:
+            log.error(
+                "TEST No workflow profile found for orchestration request. Context: %s",
+                context,
+            )
+            return
         log.info("Found workflow profile for orchestration request. Context: %s", context)
         result = workflow.execute(
             user_input=ai_orchestration_request.user_input,

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -39,13 +39,13 @@ def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs
         }
 
         workflow = AIWorkflowScope.get_profile(**context)
-        log.info(f"TEST Found workflow profile for orchestration request: {workflow}")
+        log.info("Found workflow profile for orchestration request. Context: %s", context)
         result = workflow.execute(
             user_input=ai_orchestration_request.user_input,
             action=ai_orchestration_request.action,
             user=user,
             running_context=context,
         )
-        log.info(f"TEST Successfully ran orchestrator for workflow with result: {result}")
-    except Exception as e:
-        log.exception(f"TEST Error running orchestrator for workflow: {e}")
+        log.info("Successfully ran orchestrator for workflow. Context: %s", context)
+    except Exception:
+        log.exception("Error running orchestrator for workflow")

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 
 @receiver(AI_ORCHESTRATION_REQUESTED)
-def handle_ai_orchestration_requested(_sender, ai_orchestration_request, **kwargs):
+def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs):  # pylint: disable=unused-argument
     """
     Triggered when any app publishes AI_ORCHESTRATION_REQUESTED.
 

--- a/backend/openedx_ai_extensions/receivers.py
+++ b/backend/openedx_ai_extensions/receivers.py
@@ -1,0 +1,51 @@
+"""
+Django signal receivers for openedx-ai-extensions.
+This is the entry point that bridges the event bus → orchestrator.
+"""
+import logging
+import profile
+
+from django.dispatch import receiver
+
+from openedx_ai_extensions.events.signals import AI_ORCHESTRATION_REQUESTED
+
+log = logging.getLogger(__name__)
+
+
+@receiver(AI_ORCHESTRATION_REQUESTED)
+def handle_ai_orchestration_requested(sender, ai_orchestration_request, **kwargs):
+    """
+    Triggered when any app publishes AI_ORCHESTRATION_REQUESTED, either
+    in-process (direct Django signal) or via the event bus consumer loop.
+
+    Looks up the AIWorkflowProfile by slug and runs the orchestrator.
+    """
+    from openedx_ai_extensions.workflows.models import AIWorkflowScope
+    from django.contrib.auth import get_user_model
+
+    User = get_user_model()
+
+    # Run the orchestrator with the provided input data
+    try:
+        user = User.objects.get(id=ai_orchestration_request.user_id) if ai_orchestration_request.user_id else None
+        context = {
+            k: v
+            for k, v in {
+                "course_id": ai_orchestration_request.course_id if ai_orchestration_request.course_id else None,
+                "location_id": ai_orchestration_request.location_id if ai_orchestration_request.location_id else None,
+                "ui_slot_selector_id": ai_orchestration_request.ui_slot_selector_id,
+            }.items()
+            if v is not None
+        }
+
+        workflow = AIWorkflowScope.get_profile(**context)
+        log.info(f"TEST Found workflow profile for orchestration request: {workflow}")
+        result = workflow.execute(
+            user_input=ai_orchestration_request.user_input,
+            action=ai_orchestration_request.action,
+            user=user,
+            running_context=context,
+        )
+        log.info(f"TEST Successfully ran orchestrator for workflow with result: {result}")
+    except Exception as e:
+        log.exception(f"TEST Error running orchestrator for workflow: {e}")

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -124,7 +124,8 @@ def plugin_settings(settings):
             settings.EVENT_TRACKING_BACKENDS_ALLOWED_CALIPER_EVENTS,
         ))
 
-    if hasattr(settings, 'AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER') and settings.AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER:
+    if (hasattr(settings, 'AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER') and
+            settings.AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER):
         if not getattr(settings, 'EVENT_BUS_CONSUMER', None):
             settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
 

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -124,13 +124,14 @@ def plugin_settings(settings):
             settings.EVENT_TRACKING_BACKENDS_ALLOWED_CALIPER_EVENTS,
         ))
 
-    settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
+    if hasattr(settings, 'AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER') and settings.AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER:
+        settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
 
-    settings.EVENT_BUS_CONSUMER_CONFIG = {
-        "org.openedx.ai_extensions.orchestration.requested.v1": {
-            "ai-orchestration-requests": {
-                "group_id": "ai-extensions-orchestrator",
-                "enabled": True,
+        settings.EVENT_BUS_CONSUMER_CONFIG = {
+            "org.openedx.ai_extensions.orchestration.requested.v1": {
+                "ai-orchestration-requests": {
+                    "group_id": "ai-extensions-orchestrator",
+                    "enabled": True,
+                }
             }
         }
-    }

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -125,13 +125,14 @@ def plugin_settings(settings):
         ))
 
     if hasattr(settings, 'AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER') and settings.AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER:
-        settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
+        if not getattr(settings, 'EVENT_BUS_CONSUMER', None):
+            settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
 
-        settings.EVENT_BUS_CONSUMER_CONFIG = {
-            "org.openedx.ai_extensions.orchestration.requested.v1": {
-                "ai-orchestration-requests": {
-                    "group_id": "ai-extensions-orchestrator",
-                    "enabled": True,
-                }
-            }
-        }
+        consumer_config = getattr(settings, 'EVENT_BUS_CONSUMER_CONFIG', {})
+        event_type = "org.openedx.ai_extensions.orchestration.requested.v1"
+        topic = "ai-orchestration-requests"
+        consumer_config.setdefault(event_type, {}).setdefault(topic, {
+            "group_id": "ai-extensions-orchestrator",
+            "enabled": True,
+        })
+        settings.EVENT_BUS_CONSUMER_CONFIG = consumer_config

--- a/backend/openedx_ai_extensions/settings/common.py
+++ b/backend/openedx_ai_extensions/settings/common.py
@@ -123,3 +123,14 @@ def plugin_settings(settings):
             settings.EVENT_TRACKING_BACKENDS_ALLOWED_XAPI_EVENTS,
             settings.EVENT_TRACKING_BACKENDS_ALLOWED_CALIPER_EVENTS,
         ))
+
+    settings.EVENT_BUS_CONSUMER = "edx_event_bus_redis.RedisEventConsumer"
+
+    settings.EVENT_BUS_CONSUMER_CONFIG = {
+        "org.openedx.ai_extensions.orchestration.requested.v1": {
+            "ai-orchestration-requests": {
+                "group_id": "ai-extensions-orchestrator",
+                "enabled": True,
+            }
+        }
+    }

--- a/backend/requirements/base.in
+++ b/backend/requirements/base.in
@@ -8,6 +8,7 @@ edx-opaque-keys        # Open edX CourseKeyField
 litellm            # LLM Gateway to provide model access
 event-tracking              # Allows the backend to emit tracking events
 edx-event-routing-backends  # Extends xAPI transformer events for this package
+openedx-events
 openedx-atlas
 edx-submissions
 beautifulsoup4

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -215,6 +215,7 @@ kombu==5.6.1
     # via celery
 litellm==1.80.16
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.in
 markupsafe==3.0.3
     # via jinja2
@@ -227,7 +228,9 @@ openai==2.15.0
 openedx-atlas==0.7.0
     # via -r requirements/base.in
 openedx-events==10.5.0
-    # via event-tracking
+    # via
+    #   -r requirements/base.in
+    #   event-tracking
 openedx-filters==2.1.0
     # via edx-event-routing-backends
 packaging==25.0

--- a/backend/requirements/dev.txt
+++ b/backend/requirements/dev.txt
@@ -382,6 +382,7 @@ kombu==5.6.1
     #   celery
 litellm==1.80.16
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/quality.txt
 lxml[html-clean]==5.3.2
     # via

--- a/backend/requirements/doc.txt
+++ b/backend/requirements/doc.txt
@@ -125,6 +125,7 @@ cryptography==46.0.3
     # via
     #   -r requirements/test.txt
     #   django-fernet-fields-v2
+    #   secretstorage
 ddt==1.7.2
     # via -r requirements/test.txt
 distro==1.9.0
@@ -134,6 +135,7 @@ distro==1.9.0
 django==4.2.20
     # via
     #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-crum
     #   django-extensions
@@ -330,6 +332,10 @@ jaraco-context==6.0.1
     # via keyring
 jaraco-functools==4.1.0
     # via keyring
+jeepney==0.9.0
+    # via
+    #   keyring
+    #   secretstorage
 jinja2==3.1.6
     # via
     #   -r requirements/test.txt
@@ -542,6 +548,8 @@ rpds-py==0.27.1
     #   -r requirements/test.txt
     #   jsonschema
     #   referencing
+secretstorage==3.5.0
+    # via keyring
 six==1.17.0
     # via
     #   -r requirements/test.txt

--- a/backend/requirements/quality.txt
+++ b/backend/requirements/quality.txt
@@ -345,6 +345,7 @@ kombu==5.6.1
     #   celery
 litellm==1.80.16
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/test.txt
 markupsafe==3.0.3
     # via

--- a/backend/requirements/test.txt
+++ b/backend/requirements/test.txt
@@ -323,6 +323,7 @@ kombu==5.6.1
     #   celery
 litellm==1.80.16
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/base.txt
 markupsafe==3.0.3
     # via

--- a/backend/tests/test_events.py
+++ b/backend/tests/test_events.py
@@ -1,0 +1,80 @@
+"""
+Tests for openedx_ai_extensions.events (data classes and signal definition).
+"""
+import pytest
+
+from openedx_ai_extensions.events.data import AIOrchestrationRequestData
+from openedx_ai_extensions.events.signals import AI_ORCHESTRATION_REQUESTED
+
+EVENT_TYPE = "org.openedx.ai_extensions.orchestration.requested.v1"
+
+
+# ---------------------------------------------------------------------------
+# AIOrchestrationRequestData
+# ---------------------------------------------------------------------------
+
+class TestAIOrchestrationRequestData:
+    """Unit tests for the event payload data class."""
+
+    def test_required_field_user_id(self):
+        data = AIOrchestrationRequestData(user_id=42)
+        assert data.user_id == 42
+
+    def test_optional_fields_default_to_none(self):
+        data = AIOrchestrationRequestData(user_id=1)
+        assert data.course_id is None
+        assert data.location_id is None
+        assert data.ui_slot_selector_id is None
+
+    def test_action_defaults_to_run(self):
+        data = AIOrchestrationRequestData(user_id=1)
+        assert data.action == "run"
+
+    def test_user_input_defaults_to_empty_dict(self):
+        data = AIOrchestrationRequestData(user_id=1)
+        assert data.user_input == {}
+
+    def test_all_fields_can_be_set(self):
+        data = AIOrchestrationRequestData(
+            user_id=7,
+            course_id="course-v1:edX+Demo+2025",
+            location_id="block-v1:edX+Demo+2025+type@html+block@abc",
+            ui_slot_selector_id="SLOT_X",
+            user_input={"text": "hi"},
+            action="summarise",
+        )
+        assert data.course_id == "course-v1:edX+Demo+2025"
+        assert data.ui_slot_selector_id == "SLOT_X"
+        assert data.action == "summarise"
+
+    def test_frozen_raises_on_mutation(self):
+        """Data class must be immutable (frozen=True)."""
+        data = AIOrchestrationRequestData(user_id=1)
+        with pytest.raises(Exception):  # attr raises FrozenInstanceError
+            data.user_id = 99  # type: ignore[misc]
+
+    def test_user_input_instances_are_independent(self):
+        """Each instance should get its own default dict, not a shared one."""
+        a = AIOrchestrationRequestData(user_id=1)
+        b = AIOrchestrationRequestData(user_id=2)
+        assert a.user_input is not b.user_input
+
+
+# ---------------------------------------------------------------------------
+# AI_ORCHESTRATION_REQUESTED signal
+# ---------------------------------------------------------------------------
+
+class TestAIOrchestrationRequestedSignal:
+    """Unit tests for the public OpenEdxPublicSignal definition."""
+
+    def test_event_type(self):
+        assert AI_ORCHESTRATION_REQUESTED.event_type == EVENT_TYPE
+
+    def test_init_data_contains_request_key(self):
+        assert "ai_orchestration_request" in AI_ORCHESTRATION_REQUESTED.init_data
+
+    def test_init_data_maps_to_correct_class(self):
+        assert (
+            AI_ORCHESTRATION_REQUESTED.init_data["ai_orchestration_request"]
+            is AIOrchestrationRequestData
+        )

--- a/backend/tests/test_plugin_integration.py
+++ b/backend/tests/test_plugin_integration.py
@@ -1,9 +1,12 @@
 """
 Tests to verify the plugin is discoverable and loaded correctly.
 """
+from types import SimpleNamespace
 
 from django.apps import apps
 from django.conf import settings
+
+import openedx_ai_extensions.settings.common as common_settings
 
 
 def test_app_is_installed():
@@ -24,3 +27,76 @@ def test_app_is_installed():
 
 # We don't do a test for the URLs because the namespaced urls which should be auto registered are tested in the
 # test_api.py tests.
+
+
+# ---------------------------------------------------------------------------
+# Event bus consumer settings (AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER)
+# ---------------------------------------------------------------------------
+
+EVENT_TYPE = "org.openedx.ai_extensions.orchestration.requested.v1"
+TOPIC = "ai-orchestration-requests"
+
+
+def _minimal_settings(**extra):
+    """Return a minimal settings namespace accepted by plugin_settings."""
+    ns = SimpleNamespace(
+        EVENT_TRACKING_BACKENDS={},
+        EVENT_TRACKING_BACKENDS_ALLOWED_XAPI_EVENTS=[],
+        EVENT_TRACKING_BACKENDS_ALLOWED_CALIPER_EVENTS=[],
+        **extra,
+    )
+    return ns
+
+
+def test_event_bus_consumer_not_set_when_flag_absent():
+    """EVENT_BUS_CONSUMER_CONFIG must not be touched when the flag is absent."""
+    fake = _minimal_settings()
+    common_settings.plugin_settings(fake)
+    assert not hasattr(fake, "EVENT_BUS_CONSUMER_CONFIG")
+    assert not hasattr(fake, "EVENT_BUS_CONSUMER")
+
+
+def test_event_bus_consumer_not_set_when_flag_false():
+    """EVENT_BUS_CONSUMER_CONFIG must not be touched when the flag is False."""
+    fake = _minimal_settings(AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER=False)
+    common_settings.plugin_settings(fake)
+    assert not hasattr(fake, "EVENT_BUS_CONSUMER_CONFIG")
+    assert not hasattr(fake, "EVENT_BUS_CONSUMER")
+
+
+def test_event_bus_consumer_set_when_flag_true():
+    """When the flag is True, consumer settings are injected."""
+    fake = _minimal_settings(AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER=True)
+    common_settings.plugin_settings(fake)
+
+    assert fake.EVENT_BUS_CONSUMER == "edx_event_bus_redis.RedisEventConsumer"
+    assert EVENT_TYPE in fake.EVENT_BUS_CONSUMER_CONFIG
+    assert TOPIC in fake.EVENT_BUS_CONSUMER_CONFIG[EVENT_TYPE]
+    topic_cfg = fake.EVENT_BUS_CONSUMER_CONFIG[EVENT_TYPE][TOPIC]
+    assert topic_cfg["group_id"] == "ai-extensions-orchestrator"
+    assert topic_cfg["enabled"] is True
+
+
+def test_event_bus_consumer_does_not_overwrite_existing_consumer():
+    """If EVENT_BUS_CONSUMER is already set, it must not be overwritten."""
+    fake = _minimal_settings(
+        AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER=True,
+        EVENT_BUS_CONSUMER="my.custom.Consumer",
+    )
+    common_settings.plugin_settings(fake)
+    assert fake.EVENT_BUS_CONSUMER == "my.custom.Consumer"
+
+
+def test_event_bus_consumer_config_merges_with_existing():
+    """Existing EVENT_BUS_CONSUMER_CONFIG keys must not be wiped out."""
+    existing_config = {"org.openedx.other.event.v1": {"other-topic": {"enabled": True}}}
+    fake = _minimal_settings(
+        AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER=True,
+        EVENT_BUS_CONSUMER_CONFIG=existing_config,
+    )
+    common_settings.plugin_settings(fake)
+
+    # The pre-existing key must still be present
+    assert "org.openedx.other.event.v1" in fake.EVENT_BUS_CONSUMER_CONFIG
+    # And the new event type must also have been added
+    assert EVENT_TYPE in fake.EVENT_BUS_CONSUMER_CONFIG

--- a/backend/tests/test_receivers.py
+++ b/backend/tests/test_receivers.py
@@ -1,0 +1,156 @@
+"""
+Tests for openedx_ai_extensions.receivers.
+
+Covers the handle_ai_orchestration_requested signal receiver:
+- happy path (workflow found, execute called)
+- no workflow found (early return, error logged)
+- exceptions are re-raised
+- None-valued context fields are filtered out (compact behaviour)
+- receiver is wired to AI_ORCHESTRATION_REQUESTED
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.contrib.auth import get_user_model
+
+from openedx_ai_extensions.events.data import AIOrchestrationRequestData
+from openedx_ai_extensions.events.signals import AI_ORCHESTRATION_REQUESTED
+from openedx_ai_extensions.receivers import handle_ai_orchestration_requested
+
+User = get_user_model()
+
+EVENT_TYPE = "org.openedx.ai_extensions.orchestration.requested.v1"
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def regular_user(db):  # pylint: disable=unused-argument
+    return User.objects.create_user(
+        username="receiver_test_user",
+        email="receiver@example.com",
+        password="secret",
+    )
+
+
+def _make_request(**kwargs):
+    """Return an AIOrchestrationRequestData with sensible defaults."""
+    defaults = {
+        "user_id": 1,
+        "course_id": "course-v1:edX+Demo+2025",
+        "location_id": None,
+        "ui_slot_selector_id": "SLOT_A",
+        "user_input": {"text": "hello"},
+        "action": "run",
+    }
+    defaults.update(kwargs)
+    return AIOrchestrationRequestData(**defaults)
+
+
+def _call_handler(request_data):
+    """Call the receiver directly, bypassing send_robust signal dispatch."""
+    handle_ai_orchestration_requested(
+        sender=None,
+        ai_orchestration_request=request_data,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.django_db
+def test_happy_path_executes_workflow(regular_user):  # pylint: disable=redefined-outer-name
+    """Workflow is found and execute() is called with the right arguments."""
+    request_data = _make_request(user_id=regular_user.id)
+    mock_workflow = MagicMock()
+
+    with patch(
+        "openedx_ai_extensions.receivers.AIWorkflowScope.get_profile",
+        return_value=mock_workflow,
+    ):
+        _call_handler(request_data)
+
+    mock_workflow.execute.assert_called_once_with(
+        user_input=request_data.user_input,
+        action=request_data.action,
+        user=regular_user,
+        running_context={
+            "course_id": request_data.course_id,
+            "ui_slot_selector_id": request_data.ui_slot_selector_id,
+            # location_id is None → must be absent (compact removes it)
+        },
+    )
+
+
+@pytest.mark.django_db
+def test_no_workflow_returns_early_and_logs(regular_user):  # pylint: disable=redefined-outer-name
+    """When get_profile() returns None the receiver logs an error and returns."""
+    request_data = _make_request(user_id=regular_user.id)
+
+    with patch(
+        "openedx_ai_extensions.receivers.AIWorkflowScope.get_profile",
+        return_value=None,
+    ), patch("openedx_ai_extensions.receivers.log") as mock_log:
+        _call_handler(request_data)
+
+    mock_log.error.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_exception_is_reraised(regular_user):  # pylint: disable=redefined-outer-name
+    """Exceptions from execute() are logged and then re-raised."""
+    request_data = _make_request(user_id=regular_user.id)
+    boom = RuntimeError("something went wrong")
+    mock_workflow = MagicMock()
+    mock_workflow.execute.side_effect = boom
+
+    with patch(
+        "openedx_ai_extensions.receivers.AIWorkflowScope.get_profile",
+        return_value=mock_workflow,
+    ), pytest.raises(RuntimeError, match="something went wrong"):
+        _call_handler(request_data)
+
+
+@pytest.mark.django_db
+def test_compact_filters_none_values(regular_user):  # pylint: disable=redefined-outer-name
+    """None-valued fields are excluded from the context passed to get_profile."""
+    request_data = _make_request(
+        user_id=regular_user.id,
+        course_id=None,
+        location_id=None,
+        ui_slot_selector_id="SLOT_B",
+    )
+    mock_workflow = MagicMock()
+
+    with patch(
+        "openedx_ai_extensions.receivers.AIWorkflowScope.get_profile",
+        return_value=mock_workflow,
+    ) as mock_get_profile:
+        _call_handler(request_data)
+
+    called_context = mock_get_profile.call_args[1]
+    assert "course_id" not in called_context
+    assert "location_id" not in called_context
+    assert called_context["ui_slot_selector_id"] == "SLOT_B"
+
+
+@pytest.mark.django_db
+def test_user_not_found_raises(db):  # pylint: disable=unused-argument
+    """DoesNotExist from User.objects.get is re-raised (goes through except/raise)."""
+    request_data = _make_request(user_id=999_999)
+
+    with pytest.raises(User.DoesNotExist):
+        _call_handler(request_data)
+
+
+def test_receiver_is_connected_to_signal():
+    """The handler must be registered as a receiver for AI_ORCHESTRATION_REQUESTED."""
+    # Look for the handler id in the signal's receiver list
+    receiver_ids = [r[0] for r in AI_ORCHESTRATION_REQUESTED.receivers]
+    handler_id = id(handle_ai_orchestration_requested)
+    assert any(handler_id == rid[0] for rid in receiver_ids), (
+        "handle_ai_orchestration_requested is not connected to AI_ORCHESTRATION_REQUESTED"
+    )

--- a/backend/tests/test_receivers.py
+++ b/backend/tests/test_receivers.py
@@ -52,7 +52,7 @@ def _make_request(**kwargs):
 def _call_handler(request_data):
     """Call the receiver directly, bypassing send_robust signal dispatch."""
     handle_ai_orchestration_requested(
-        sender=None,
+        None,
         ai_orchestration_request=request_data,
     )
 

--- a/tutor/openedx_ai_extensions/plugin.py
+++ b/tutor/openedx_ai_extensions/plugin.py
@@ -46,6 +46,7 @@ def _mount_plugin(mounts, path):
 hooks.Filters.CONFIG_DEFAULTS.add_items([
     ("AI_EXTENSIONS_ENABLE_LLM_CACHE", False),
     ("AI_EXTENSIONS_LLM_CACHE", {}),
+    ("AI_EXTENSIONS_ENABLE_EVENT_BUS_CONSUMER", False),
 ])
 
 # Actually connects the patch files as tutor env patches


### PR DESCRIPTION
This pull request introduces a new event-driven orchestration mechanism for AI workflows in the `openedx-ai-extensions` backend. It adds a public event signal and data payload for requesting AI orchestration runs, a Django signal receiver to handle those requests, and configures the event bus consumer to listen for orchestration events. Additionally, it updates dependencies to support these changes.

**Event-driven AI orchestration:**

* Introduced a public `AI_ORCHESTRATION_REQUESTED` event signal in `signals.py` for external apps to request AI workflow runs, along with an attr-based data payload class `AIOrchestrationRequestData` in `data.py`. [[1]](diffhunk://#diff-1d1d766de104b84ecc211eba4afa09dfba1622cb11f1300e07d4a6bc48535523R1-R17) [[2]](diffhunk://#diff-c3b3a0a4cc4acd8795ae0ae90eaca41897f35136ac2519899008e071a181ad11R1-R19)
* Added a Django signal receiver in `receivers.py` that listens for `AI_ORCHESTRATION_REQUESTED` events and triggers the AI workflow orchestrator with the provided context and user input.
* Modified `apps.py` to ensure the new receivers are imported and registered when the app is ready.

**Event bus configuration:**

* Updated `settings/common.py` to configure the event bus consumer to listen for the new orchestration event type and route it to the orchestrator.

**Dependency updates:**

* Added `openedx-events` to `requirements/base.in` and updated related requirements files to ensure compatibility and support for event-driven features. [[1]](diffhunk://#diff-930c90821797b3eed215c57ad83e0ffb363d8d473275dfee36fa88498aed558dR11) [[2]](diffhunk://#diff-7bb86c3a64c5540b9b7a466b3e821f08386653d4ef1caa48c0f184af755e27fdL230-R233)
* Added and annotated several dependencies in requirements files to support new functionality and maintain compatibility. [[1]](diffhunk://#diff-7bb86c3a64c5540b9b7a466b3e821f08386653d4ef1caa48c0f184af755e27fdR218) [[2]](diffhunk://#diff-54108218b1d4024db26281d39373b8e30e90012402c2db42d513b1681e04deafR385) [[3]](diffhunk://#diff-b9a266dd649e2dcc6ec387090747f4228b589a54b69f97beae85457dc4bb0f36R128) [[4]](diffhunk://#diff-b9a266dd649e2dcc6ec387090747f4228b589a54b69f97beae85457dc4bb0f36R138) [[5]](diffhunk://#diff-b9a266dd649e2dcc6ec387090747f4228b589a54b69f97beae85457dc4bb0f36R335-R338) [[6]](diffhunk://#diff-b9a266dd649e2dcc6ec387090747f4228b589a54b69f97beae85457dc4bb0f36R551-R552) [[7]](diffhunk://#diff-0a85248ad621fdebe8470462682c2e01f646acbc6e735af7096bfc313b55e3feR348) [[8]](diffhunk://#diff-b625ab0495d760bbe06b85f6bfcc23b4a965d10ee1e9f136ab8a8127be2e020bR326)