### PR TITLE
chore: bumpversion to v2.2.0

### DIFF
--- a/backend/openedx_ai_extensions/__init__.py
+++ b/backend/openedx_ai_extensions/__init__.py
@@ -2,4 +2,4 @@
 A experimental plugin for Open edX designed to explore AI extensibility.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/openedx-ai-extensions-ui",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This pull request updates the version numbers for both the backend and frontend components of the Open edX AI Extensions project to 2.2.0.

Version bump:

* Updated the `__version__` in `backend/openedx_ai_extensions/__init__.py` from 2.1.0 to 2.2.0.
* Updated the `version` in `frontend/package.json` from 2.1.0 to 2.2.0.