### PR TITLE
fix: add default to aspects assets

### DIFF
--- a/backend/openedx_ai_extensions/__init__.py
+++ b/backend/openedx_ai_extensions/__init__.py
@@ -2,4 +2,4 @@
 A experimental plugin for Open edX designed to explore AI extensibility.
 """
 
-__version__ = "2.3.0"
+__version__ = "2.3.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/openedx-ai-extensions-ui",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/tutor/openedx_ai_extensions/templates/openedx-ai-extensions/build/assets/datasets/fact_ai_workflow_interactions.yaml
+++ b/tutor/openedx_ai_extensions/templates/openedx-ai-extensions/build/assets/datasets/fact_ai_workflow_interactions.yaml
@@ -289,7 +289,7 @@ metrics:
 normalize_columns: true
 offset: 0
 params: null
-schema: '{{ ASPECTS_XAPI_DATABASE }}'
+schema: '{{ ASPECTS_XAPI_DATABASE | default("xapi") }}'
 sql: |-
   SELECT
       event_id,
@@ -308,8 +308,8 @@ sql: |-
       nullIf(CAST(JSON_VALUE(event, '$.object.definition.extensions."https://w3id.org/xapi/openedx/extension/ai-usage".completion_tokens') AS Nullable(Int64)), 0) AS completion_tokens,
       nullIf(CAST(JSON_VALUE(event, '$.object.definition.extensions."https://w3id.org/xapi/openedx/extension/ai-usage".total_tokens') AS Nullable(Int64)), 0) AS total_tokens,
       nullIf(CAST(JSON_VALUE(event, '$.object.definition.extensions."https://w3id.org/xapi/openedx/extension/ai-usage".cost') AS Nullable(Float64)), 0) AS llm_cost
-  FROM {{ ASPECTS_XAPI_DATABASE }}.xapi_events_all_parsed xapi
-  LEFT JOIN {{ ASPECTS_EVENT_SINK_DATABASE }}.dim_course_names course_info ON course_info.course_key = xapi.course_key
+  FROM {{ ASPECTS_XAPI_DATABASE | default("xapi") }}.xapi_events_all_parsed xapi
+  LEFT JOIN {{ ASPECTS_EVENT_SINK_DATABASE | default("event_sink") }}.dim_course_names course_info ON course_info.course_key = xapi.course_key
   WHERE
       JSON_VALUE(event, '$.object.definition.type') = 'https://w3id.org/xapi/openedx/activity/ai-workflow'
 table_name: fact_ai_workflow_interactions


### PR DESCRIPTION
This pull request updates the `fact_ai_workflow_interactions.yaml` dataset template to improve default handling for database schema and table references. The main changes ensure that if the expected environment variables are not set, sensible defaults are used, which increases robustness and portability.

**Template robustness improvements:**

* Updated the `schema` parameter to use a default value of `"xapi"` if `ASPECTS_XAPI_DATABASE` is not defined, preventing errors when the variable is missing.
* Modified SQL queries to use default values (`"xapi"` for `ASPECTS_XAPI_DATABASE` and `"event_sink"` for `ASPECTS_EVENT_SINK_DATABASE`) when the corresponding variables are not set, ensuring the queries work out-of-the-box in more environments.