### PR TITLE
feat: add 'up_to_current_unit' retrieval mode to OpenEdXProcessor

### DIFF
--- a/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
+++ b/backend/openedx_ai_extensions/processors/openedx/openedx_processor.py
@@ -52,14 +52,10 @@ class OpenEdXProcessor:
         "function": {
             "name": "get_location_content",
             "description": (
-                "Get published Open edX course content into an text format."
-                "This function reads the *actual published content* of a course unit (or other"
-                "course block) exactly as it is visible to the learner in the browser and"
-                "converts it into a structured format suitable for LLM processing."
-
-                "Use this function whenever an answer depends on the specific text, questions,"
-                "instructions, or structure of the course content the user is currently viewing."
-                "Do NOT rely on prior knowledge, assumptions, or summaries of the course."
+                "Get published Open edX course content. "
+                "This function reads the content of course unit(s) and "
+                "converts it into a structured format suitable for LLM processing. "
+                "Can retrieve just the current unit, units up to the current one, or the entire sequence."
             ),
             "parameters": {
                 "type": "object",
@@ -70,14 +66,23 @@ class OpenEdXProcessor:
                             "The string representation of the location ID, "
                             "if not provided uses the current location"
                         )
+                    },
+                    "retrieval_mode": {
+                        "type": "string",
+                        "enum": ["unit", "up_to_current_unit", "sequence"],
+                        "description": (
+                            "How much content to retrieve: "
+                            "'unit' (current only), 'up_to_current_unit' (sequence up to current), "
+                            "or 'sequence' (entire sequence)."
+                        )
                     }
                 },
                 "required": []
             }
         }
     })
-    def get_location_content(self, location_id=None):
-        """Extract unit content from Open edX modulestore"""
+    def get_location_content(self, location_id=None, retrieval_mode=None):
+        """Extract unit or sequence content from Open edX modulestore based on configuration"""
         try:
             # pylint: disable=import-error,import-outside-toplevel
             from xmodule.modulestore.django import modulestore
@@ -88,27 +93,59 @@ class OpenEdXProcessor:
 
             unit_key = UsageKey.from_string(location_id)
             store = modulestore()
-            unit = store.get_item(unit_key)
 
-            unit_info = {
-                "unit_id": str(unit.location),
-                "display_name": unit.display_name,
-                "category": unit.category,
-                "blocks": [],
-            }
+            # Get retrieval_mode from arg or config, default to 'unit'
+            retrieval_mode = retrieval_mode or self.config.get("retrieval_mode", "unit")
 
-            for child_key in getattr(unit, "children", []):
-                block_info = self._extract_block(store, child_key)
-                if block_info:
-                    unit_info["blocks"].append(block_info)
+            if retrieval_mode in ("sequence", "up_to_current_unit"):
+                parent_key = store.get_parent_location(unit_key)
+                if parent_key:
+                    sequence = store.get_item(parent_key)
+                    children = getattr(sequence, "children", [])
 
-            if char_limit:
-                self._truncate_unit_text(unit_info, char_limit)
+                    if retrieval_mode == "up_to_current_unit":
+                        # Find the index of the current unit in the sequence
+                        try:
+                            current_index = children.index(unit_key)
+                            children = children[:current_index + 1]
+                        except ValueError:
+                            # Fallback if the unit isn't found in the parent's children
+                            return self._get_unit_data(store, unit_key, char_limit)
 
-            return unit_info
+                    return {
+                        "sequence_id": str(sequence.location),
+                        "display_name": sequence.display_name,
+                        "retrieval_mode": retrieval_mode,
+                        "units": [
+                            self._get_unit_data(store, child_key, char_limit)
+                            for child_key in children
+                        ]
+                    }
+
+            return self._get_unit_data(store, unit_key, char_limit)
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             return {"error": f"Error accessing content: {str(exc)}"}
+
+    def _get_unit_data(self, store, unit_key, char_limit=None):
+        """Extract content for a single unit"""
+        unit = store.get_item(unit_key)
+        unit_info = {
+            "unit_id": str(unit.location),
+            "display_name": unit.display_name,
+            "category": unit.category,
+            "blocks": [],
+        }
+
+        for child_key in getattr(unit, "children", []):
+            block_info = self._extract_block(store, child_key)
+            if block_info:
+                unit_info["blocks"].append(block_info)
+
+        if char_limit:
+            self._truncate_unit_text(unit_info, char_limit)
+
+        return unit_info
 
     def _extract_block(self, store, block_key):
         """Helper to extract block info safely"""

--- a/backend/openedx_ai_extensions/workflows/profiles/base/custom_prompt.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/base/custom_prompt.json
@@ -7,7 +7,8 @@ have it explain in a different with this prompt.
   "orchestrator_class": "DirectLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "provider": "default",

--- a/backend/openedx_ai_extensions/workflows/profiles/base/library_questions_creator.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/base/library_questions_creator.json
@@ -7,7 +7,8 @@ Works only in studio UI and over the CMS service_variant.
   "orchestrator_class": "EducatorAssistantOrchestrator",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "EducatorAssistantProcessor": {
       "function": "generate_quiz_questions",

--- a/backend/openedx_ai_extensions/workflows/profiles/base/summary.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/base/summary.json
@@ -6,7 +6,8 @@ present the streaming answer in the same box.
   "orchestrator_class": "DirectLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "summarize_content",

--- a/backend/openedx_ai_extensions/workflows/profiles/examples/anthropic/chat.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/examples/anthropic/chat.json
@@ -5,7 +5,8 @@ Test experience. Ask claude to chat having given it the current unit context
   "orchestrator_class": "ThreadedLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "chat_with_context",

--- a/backend/openedx_ai_extensions/workflows/profiles/examples/huggingface/deepseek_chat.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/examples/huggingface/deepseek_chat.json
@@ -5,7 +5,8 @@ Test experience. Use a hosted DeepSeek to chat having given it the current unit 
   "orchestrator_class": "ThreadedLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "chat_with_context",

--- a/backend/openedx_ai_extensions/workflows/profiles/examples/openai/chat.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/examples/openai/chat.json
@@ -5,7 +5,8 @@ Test experience. Ask ChatGPT to chat having given it the current unit context
   "orchestrator_class": "ThreadedLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "chat_with_context",

--- a/backend/openedx_ai_extensions/workflows/profiles/examples/openweights/qwen_summary.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/examples/openweights/qwen_summary.json
@@ -8,7 +8,8 @@ See: https://gist.github.com/felipemontoya/509495d3fbaa696fa2b684880a8388da
   "orchestrator_class": "DirectLLMResponse",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "summarize_content",

--- a/backend/openedx_ai_extensions/workflows/profiles/experimental/flashcards.json
+++ b/backend/openedx_ai_extensions/workflows/profiles/experimental/flashcards.json
@@ -7,7 +7,8 @@ Works only in Studio UI and over the CMS service_variant.
   "orchestrator_class": "openedx_ai_extensions.workflows.orchestrators.flashcards_orchestrator.FlashCardsOrchestrator",
   "processor_config": {
     "OpenEdXProcessor": {
-      "function": "get_location_content"
+      "function": "get_location_content",
+      "retrieval_mode": "unit" // Options: unit, sequence, up_to_current_unit
     },
     "LLMProcessor": {
       "function": "generate_flashcards",

--- a/backend/tests/test_openedx_processor.py
+++ b/backend/tests/test_openedx_processor.py
@@ -45,9 +45,12 @@ def mock_keys():
     """
     with patch("openedx_ai_extensions.processors.openedx.openedx_processor.UsageKey") as mock_usage:
         with patch("openedx_ai_extensions.processors.openedx.openedx_processor.CourseLocator") as mock_course:
-            # Setup default return values for keys so they act like valid objects
-            mock_usage.from_string.return_value = MagicMock(name="UnitUsageKey")
-            mock_course.from_string.return_value = MagicMock(name="CourseKey")
+            class MockKey(str):
+                def make_usage_key(self, *args, **kwargs):
+                    return MockKey("mock-usage-key")
+
+            mock_usage.from_string.side_effect = MockKey
+            mock_course.from_string.side_effect = MockKey
             yield mock_usage, mock_course
 
 
@@ -98,6 +101,163 @@ def test_get_location_content_success(mock_edx_imports, mock_keys):
     assert result.get("display_name") == "Test Unit"
     assert len(result["blocks"]) == 1
     assert result["blocks"][0]["text"] == "Block Content"
+
+
+def test_get_location_content_sequence_mode_success(mock_edx_imports, mock_keys):
+    """Test successful sequence content extraction in sequence mode."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    config = {"OpenEdXProcessor": {"retrieval_mode": "sequence"}}
+    test_processor = OpenEdXProcessor(processor_config=config)
+
+    mock_unit = MagicMock()
+    mock_unit.location = "unit-loc"
+    mock_unit.display_name = "Test Unit"
+    mock_unit.category = "vertical"
+    mock_unit.children = ["block-1"]
+
+    mock_sequence = MagicMock()
+    mock_sequence.location = "seq-loc"
+    mock_sequence.display_name = "Test Sequence"
+    mock_sequence.children = ["unit-loc", "unit-loc-2"]
+
+    mock_unit_2 = MagicMock()
+    mock_unit_2.location = "unit-loc-2"
+    mock_unit_2.display_name = "Test Unit 2"
+    mock_unit_2.category = "vertical"
+    mock_unit_2.children = ["block-2"]
+
+    mock_store = modulestore.return_value
+    mock_store.get_parent_location.return_value = "seq-loc"
+
+    # Configure get_item to return different items based on key
+    def get_item_side_effect(key):
+        if key == "seq-loc":
+            return mock_sequence
+        if key == "unit-loc-2":
+            return mock_unit_2
+        return mock_unit
+
+    mock_store.get_item.side_effect = get_item_side_effect
+
+    with patch.object(test_processor, '_extract_block') as mock_extract:
+        mock_extract.side_effect = [
+            {"text": "Unit 1 Block"},
+            {"text": "Unit 2 Block"}
+        ]
+        result = test_processor.get_location_content("unit-loc")
+
+    assert result.get("retrieval_mode") == "sequence"
+    assert result.get("display_name") == "Test Sequence"
+    assert len(result["units"]) == 2
+    assert result["units"][0]["display_name"] == "Test Unit"
+    assert result["units"][1]["display_name"] == "Test Unit 2"
+
+
+def test_get_location_content_up_to_current_unit_mode_success(mock_edx_imports, mock_keys):
+    """Test successful sequence content extraction in up_to_current_unit mode."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    config = {"OpenEdXProcessor": {"retrieval_mode": "up_to_current_unit"}}
+    test_processor = OpenEdXProcessor(processor_config=config)
+
+    mock_unit = MagicMock()
+    mock_unit.location = "unit-loc"
+    mock_unit.display_name = "Test Unit"
+    mock_unit.category = "vertical"
+    mock_unit.children = ["block-1"]
+
+    mock_unit_2 = MagicMock()
+    mock_unit_2.location = "unit-loc-2"
+    mock_unit_2.display_name = "Test Unit 2"
+
+    mock_sequence = MagicMock()
+    mock_sequence.location = "seq-loc"
+    mock_sequence.display_name = "Test Sequence"
+    mock_sequence.children = ["unit-loc", "unit-loc-2", "unit-loc-3"]
+
+    mock_store = modulestore.return_value
+    mock_store.get_parent_location.return_value = "seq-loc"
+
+    def get_item_side_effect(key):
+        if key == "seq-loc":
+            return mock_sequence
+        if key == "unit-loc-2":
+            return mock_unit_2
+        return mock_unit
+
+    mock_store.get_item.side_effect = get_item_side_effect
+
+    with patch.object(test_processor, '_extract_block', return_value={"text": "Block Content"}):
+        # We search for unit-loc-2, so we expect unit-loc and unit-loc-2
+        result = test_processor.get_location_content("unit-loc-2")
+
+    assert result.get("retrieval_mode") == "up_to_current_unit"
+    assert len(result["units"]) == 2
+    assert result["units"][0]["display_name"] == "Test Unit"
+    assert result["units"][1]["display_name"] == "Test Unit 2"
+
+
+def test_get_location_content_retrieval_mode_from_argument(mock_edx_imports, mock_keys):
+    """Test that retrieval_mode from argument overrides config."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    config = {"OpenEdXProcessor": {"retrieval_mode": "unit"}}
+    test_processor = OpenEdXProcessor(processor_config=config)
+
+    mock_unit = MagicMock()
+    mock_unit.location = "unit-loc"
+    mock_unit.display_name = "Test Unit"
+
+    mock_sequence = MagicMock()
+    mock_sequence.location = "seq-loc"
+    mock_sequence.display_name = "Test Sequence"
+    mock_sequence.children = ["unit-loc"]
+
+    mock_store = modulestore.return_value
+    mock_store.get_parent_location.return_value = "seq-loc"
+    mock_store.get_item.side_effect = lambda key: mock_sequence if key == "seq-loc" else mock_unit
+
+    with patch.object(test_processor, '_extract_block', return_value={"text": "Block Content"}):
+        # Override 'unit' config with 'sequence' argument
+        result = test_processor.get_location_content("unit-loc", retrieval_mode="sequence")
+
+    assert result.get("retrieval_mode") == "sequence"
+    assert "units" in result
+
+
+def test_get_location_content_sequence_mode_no_parent(mock_edx_imports, mock_keys):
+    """Test that sequence mode falls back to unit if no parent is found."""
+    # pylint: disable=unused-argument
+    # pylint: disable=import-error, import-outside-toplevel
+    from xmodule.modulestore.django import modulestore
+
+    config = {"OpenEdXProcessor": {"retrieval_mode": "sequence"}}
+    test_processor = OpenEdXProcessor(processor_config=config)
+
+    mock_unit = MagicMock()
+    mock_unit.location = "unit-loc"
+    mock_unit.display_name = "Test Unit"
+    mock_unit.category = "vertical"
+    mock_unit.children = ["block-1"]
+
+    mock_store = modulestore.return_value
+    mock_store.get_parent_location.return_value = None
+    mock_store.get_item.return_value = mock_unit
+
+    with patch.object(test_processor, '_extract_block', return_value={"text": "Block Content"}):
+        result = test_processor.get_location_content("unit-loc")
+
+    # Should fall back to unit data
+    assert "units" not in result
+    assert result.get("display_name") == "Test Unit"
+    assert len(result["blocks"]) == 1
 
 
 def test_get_location_content_truncation(mock_edx_imports, mock_keys):


### PR DESCRIPTION
## Overview
The `retrieval_mode` feature allows AI interactions to leverage context beyond the immediate unit where the interaction is happening. This is particularly useful for courses with granular content structures where a single unit may not provide enough context for meaningful AI responses.

## Configuration Options
The system now supports three primary retrieval modes:
- `unit` (Default): Retrieves content only from the current unit.
- `up_to_current_unit`: Retrieves content from the sequence up to (and including) the current unit.
- `sequence`: Retrieves content from the entire parent sequence (e.g., all units in the same lesson/subsection).

## How it Works
The `OpenEdXProcessor` determines the `retrieval_mode` from its configuration (typically defined in the active workflow profile's JSON file).

### Example: Setting in a Workflow Profile (`.json` file)
To enable sequence-level retrieval for a specific workflow, add `"retrieval_mode": "sequence"` to the `OpenEdXProcessor` configuration:

```json
{
  "orchestrator_class": "DirectLLMResponse",
  "processor_config": {
    "OpenEdXProcessor": {
      "function": "get_location_content",
      "retrieval_mode": "sequence"
    },
    "LLMProcessor": {
      "provider": "default",
      "prompt": "Summarize the lesson content provided below..."
    }
  }
}
```

## Technical Implementation
- **Processor Logic:** In `openedx_processor.py`, the `get_location_content` method checks `self.config` for `retrieval_mode`.
- **Sequence Retrieval:** If set to `sequence`, it uses `store.get_parent_location(unit_key)` to find the parent sequence and retrieves content for all its child units using a new `_get_unit_data` helper method.
- **Data Structure:** 
  - In `unit` mode, the returned JSON contains data for a single unit.
  - In `sequence` mode, the returned JSON contains a `sequence_id`, `display_name`, and a `units` list containing the processed content of every unit in that sequence.
- **Fallback Safety:** If a parent sequence cannot be found, the system gracefully falls back to returning the single unit's content.

Issue: https://github.com/openedx/openedx-ai-extensions/issues/173
