### PR TITLE
fix: correcting build error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,9 @@ jobs:
       - name: Run linting
         run: npm run lint
 
+      - name: Run type check
+        run: npm run types
+
       - name: Run test
         run: npm run test
 

--- a/backend/openedx_ai_extensions/__init__.py
+++ b/backend/openedx_ai_extensions/__init__.py
@@ -2,4 +2,4 @@
 A experimental plugin for Open edX designed to explore AI extensibility.
 """
 
-__version__ = "2.4.0"
+__version__ = "2.4.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openedx/openedx-ai-extensions-ui",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "AI Extensions UI component for Open edX utilizing Frontend Plugin Framework",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/frontend/src/ai-extensions-settings/components/WorkflowsConfigTab.tsx
+++ b/frontend/src/ai-extensions-settings/components/WorkflowsConfigTab.tsx
@@ -163,6 +163,7 @@ const PromptView = ({
         isOpen={showConfirm}
         onClose={() => setShowConfirm(false)}
         hasCloseButton
+        isOverflowVisible={false}
       >
         <ModalDialog.Header>
           <ModalDialog.Title>


### PR DESCRIPTION
This error showed up when building the mfe image downstream.

```bash
[4](https://github.com/eduNEXT/aiext-azimut-project/actions/runs/25584365364/job/75109876295#step:19:3135)
128.6 ./node_modules/.bin/tsc -p tsconfig.build.json --emitDeclarationOnly
145.8 src/ai-extensions-settings/components/WorkflowsConfigTab.tsx(161,8): error TS2741: Property 'isOverflowVisible' is missing in type '{ children: Element[]; title: any; isOpen: boolean; onClose: () => void; hasCloseButton: true; }' but required in type 'Pick<Props, keyof Props>'.
145.9 make: *** [Makefile:13: build] Error 2
```

To avoid this ever happening again, I'm also editing the CI to check types.