### PR TITLE
feat: adding timestamp for sessions

### DIFF
--- a/backend/openedx_ai_extensions/admin.py
+++ b/backend/openedx_ai_extensions/admin.py
@@ -356,14 +356,17 @@ class AIWorkflowSessionAdmin(admin.ModelAdmin):
     Admin interface for managing AI Workflow Sessions.
     """
 
-    list_display = ("user", "course_id", "profile_slug", "location_id")
+    list_display = ("user", "course_id", "profile_slug", "location_id", "created_at", "updated_at")
     search_fields = ("user__username", "course_id", "location_id", "profile__slug")
+    list_filter = ("created_at",)
+    date_hierarchy = "created_at"
     list_select_related = ("user", "profile")
     readonly_fields = (
         "user_link", "scope_link", "profile_link",
         "course_id", "location_id",
         "local_submission_id_link", "remote_response_id",
         "debug_link", "metadata_pretty",
+        "created_at", "updated_at",
     )
     exclude = ("user", "scope", "profile", "local_submission_id", "metadata")
     actions = ["debug_thread"]

--- a/backend/openedx_ai_extensions/migrations/0008_aiworkflowsession_timestamps.py
+++ b/backend/openedx_ai_extensions/migrations/0008_aiworkflowsession_timestamps.py
@@ -1,0 +1,22 @@
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('openedx_ai_extensions', '0007_aiworkflowscope_specificity_index_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='aiworkflowsession',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='aiworkflowsession',
+            name='updated_at',
+            field=models.DateTimeField(auto_now=True, null=True),
+        ),
+    ]

--- a/backend/openedx_ai_extensions/workflows/models.py
+++ b/backend/openedx_ai_extensions/workflows/models.py
@@ -481,6 +481,8 @@ class AIWorkflowSession(models.Model):
         help_text="ID of the last response sent to the user",
     )
     metadata = models.JSONField(default=dict, help_text="Additional session metadata")
+    created_at = models.DateTimeField(auto_now_add=True, null=True)
+    updated_at = models.DateTimeField(auto_now=True, null=True)
 
     class Meta:
         unique_together = ("user", "scope", "profile", "course_id", "location_id")


### PR DESCRIPTION
Simple PR to add timestamps for ai_sessions.  This is very helpful when trying to review or debug the inner workings of the AI from the Django admin.