### PR TITLE
chore: move comment trigger to separate file

### DIFF
--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -1,0 +1,55 @@
+name: Trigger Integration Tests
+
+on:
+  issue_comment:
+    types:
+      - created
+
+jobs:
+  trigger:
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/integration-test') &&
+      (
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'OWNER'
+      )
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Get PR details
+        id: pr
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            core.setOutput('head_sha', pr.data.head.sha);
+            core.setOutput('head_ref', pr.data.head.ref);
+            core.setOutput('head_repo', pr.data.head.repo.full_name);
+
+      - name: Dispatch integration workflow
+        uses: actions/github-script@v9
+        with:
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'integration-tests.yml',
+              ref: 'main',
+              inputs: {
+                sha: '${{ steps.pr.outputs.head_sha }}',
+                ref: '${{ steps.pr.outputs.head_ref }}',
+                repository: '${{ steps.pr.outputs.head_repo }}'
+              }
+            });

--- a/.github/workflows/integration-test-trigger.yml
+++ b/.github/workflows/integration-test-trigger.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Get PR details
         id: pr
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -39,7 +39,7 @@ jobs:
             core.setOutput('head_repo', pr.data.head.repo.full_name);
 
       - name: Dispatch integration workflow
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.actions.createWorkflowDispatch({

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -6,27 +6,22 @@ on:
       - main
 
   workflow_dispatch:
+    inputs:
+      sha:
+        required: false
+        type: string
 
-  issue_comment:
-    types:
-      - created
+      ref:
+        required: false
+        type: string
+
+      repository:
+        required: false
+        type: string
 
 jobs:
   integration:
     name: Live LLM Integration Tests
-
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        startsWith(github.event.comment.body, '/integration-test') &&
-        (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'OWNER'
-        )
-      )
 
     runs-on: ubuntu-latest
 
@@ -35,34 +30,19 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - name: Get PR details
-        if: github.event_name == 'issue_comment'
-        id: pr
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      - name: Checkout PR commit
+        if: inputs.sha != ''
+        uses: actions/checkout@v4
         with:
-          script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.issue.number
-            });
-
-            core.setOutput('head_ref', pr.data.head.ref);
-            core.setOutput('head_repo', pr.data.head.repo.full_name);
-
-      - name: Checkout PR branch
-        if: github.event_name == 'issue_comment'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  #v4.3.1
-        with:
-          repository: ${{ steps.pr.outputs.head_repo }}
-          ref: ${{ steps.pr.outputs.head_ref }}
+          repository: ${{ inputs.repository }}
+          ref: ${{ inputs.sha }}
 
       - name: Checkout repository
-        if: github.event_name != 'issue_comment'
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  #v4.3.1
+        if: inputs.sha == ''
+        uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      checks: write
+      statuses: write
       contents: read
 
     defaults:
@@ -34,21 +34,19 @@ jobs:
         working-directory: ./backend
 
     steps:
-      - name: Create check run
+      - name: Set pending status
         if: inputs.sha != ''
-        id: check
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const { data: check } = await github.rest.checks.create({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              name: 'Live LLM Integration Tests',
-              head_sha: '${{ inputs.sha }}',
-              status: 'in_progress',
-              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+              sha: '${{ inputs.sha }}',
+              state: 'pending',
+              context: 'Live LLM Integration Tests',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });
-            core.setOutput('check_id', check.id);
 
       - name: Checkout PR commit
         if: inputs.sha != ''
@@ -78,15 +76,16 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: make test-integration
 
-      - name: Complete check run
+      - name: Set final status
         if: always() && inputs.sha != ''
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            await github.rest.checks.update({
+            await github.rest.repos.createCommitStatus({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              check_run_id: ${{ steps.check.outputs.check_id }},
-              status: 'completed',
-              conclusion: '${{ steps.tests.outcome }}' === 'success' ? 'success' : 'failure'
+              sha: '${{ inputs.sha }}',
+              state: '${{ steps.tests.outcome }}' === 'success' ? 'success' : 'failure',
+              context: 'Live LLM Integration Tests',
+              target_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
             });

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,11 +25,31 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      checks: write
+      contents: read
+
     defaults:
       run:
         working-directory: ./backend
 
     steps:
+      - name: Create check run
+        if: inputs.sha != ''
+        id: check
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: check } = await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Live LLM Integration Tests',
+              head_sha: '${{ inputs.sha }}',
+              status: 'in_progress',
+              details_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`
+            });
+            core.setOutput('check_id', check.id);
+
       - name: Checkout PR commit
         if: inputs.sha != ''
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  #v4.3.1
@@ -52,7 +72,21 @@ jobs:
           pip install -e .
 
       - name: Run integration tests
+        id: tests
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: make test-integration
+
+      - name: Complete check run
+        if: always() && inputs.sha != ''
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: ${{ steps.check.outputs.check_id }},
+              status: 'completed',
+              conclusion: '${{ steps.tests.outcome }}' === 'success' ? 'success' : 'failure'
+            });

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -32,17 +32,17 @@ jobs:
     steps:
       - name: Checkout PR commit
         if: inputs.sha != ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  #v4.3.1
         with:
           repository: ${{ inputs.repository }}
           ref: ${{ inputs.sha }}
 
       - name: Checkout repository
         if: inputs.sha == ''
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  #v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12"
 

--- a/backend/test_settings.py
+++ b/backend/test_settings.py
@@ -114,7 +114,7 @@ LOGGING = {
     },
     "root": {
         "handlers": ["console"],
-        "level": "DEBUG",
+        "level": "INFO",
     },
 }
 


### PR DESCRIPTION
This PR split the on-comment trigger to another files extracting sha, it allow the PR to have the check shown in the UI.

Also move log level to INFO to avoid DEBUG logging