### PR TITLE
chore: fix integrations tests

### DIFF
--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -195,8 +195,7 @@ class LLMProcessor(LitellmProcessor):
                 result["system_messages"] = system_msgs
             return result
         except BadRequestError as e:
-            error_code = getattr(e, "code", str(e))
-            if "previous_response_not_found" in str(error_code):
+            if "previous_response_not_found" in str(e):
                 logger.warning(
                     "Previous response ID '%s' not found. Clearing and retrying with full history fallback.",
                     self.user_session.remote_response_id if self.user_session else "Unknown"

--- a/backend/openedx_ai_extensions/processors/llm/llm_processor.py
+++ b/backend/openedx_ai_extensions/processors/llm/llm_processor.py
@@ -195,7 +195,7 @@ class LLMProcessor(LitellmProcessor):
                 result["system_messages"] = system_msgs
             return result
         except BadRequestError as e:
-            if "previous_response_not_found" in str(e):
+            if "previous_response_not_found" in str(getattr(e, "code", None) or str(e)):
                 logger.warning(
                     "Previous response ID '%s' not found. Clearing and retrying with full history fallback.",
                     self.user_session.remote_response_id if self.user_session else "Unknown"


### PR DESCRIPTION
Fix stale-thread recovery not triggering for OpenAI Responses API

LLMProcessor._call_responses_wrapper catches BadRequestError and checks e.code to detect an expired previous_response_id (previous_response_not_found) so it can clear the stale ID and retry with full history. In practice e.code is unreliable — litellm/openai's exception wiring doesn't consistently populate it across call paths and litellm versions, so the real error code only reliably shows up in the exception message (str(e)).

This caused test_stale_thread_id_triggers_recovery and test_conversation_clean_after_stale_thread_recovery to fail in CI
