### PR TITLE
chore: Relax dependencies to support Open edX Verawood

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "tutor>=20.0.0,<22.0.0",
-    "tutor-mfe>=20.0.0,<22.0.0",
+    "tutor>=20.0.0,<23.0.0",
+    "tutor-mfe>=20.0.0,<23.0.0",
 ]
 
 # these fields will be set by .hatch_build.py
@@ -33,7 +33,7 @@ dynamic = ["version"]
 
 [project.optional-dependencies]
 dev = [
-    "tutor[dev]>=20.0.0,<22.0.0",
+    "tutor[dev]>=20.0.0,<23.0.0",
     "pylint",
 ]
 


### PR DESCRIPTION
## Description

Bump the `tutor` and `tutor-mfe` upper bounds from `<22` to `<23` so the plugin can be installed on **Open edX Verawood** (tutor 22 / tutor-mfe 22).

Currently every release (up to v2.9.1) and `main` pin `tutor>=20,<22` / `tutor-mfe>=20,<22`, which makes the plugin uninstallable on a Verawood stack:

```
openedx-ai-extensions depends on tutor-mfe<22.0.0 and >=20.0.0
tutor-contrib-mfe-extensions 22.0.0 depends on tutor-mfe~=22.0
=> ResolutionImpossible
```

This mirrors the Ulmo support change in #176 (which relaxed `<21` → `<22`).

## Testing
- [ ] Install on an Open edX Verawood (tutor 22) build and verify plugin loads / MFE hooks work.
